### PR TITLE
refactor: move legacy Bash files to legacy/ directory after Go migration

### DIFF
--- a/docs/implementation/tmux-intray-implementation-comparison.md
+++ b/docs/implementation/tmux-intray-implementation-comparison.md
@@ -17,7 +17,7 @@ The tmux-intray project has implemented **significant portions** of the planned 
 | Updated `add` command using new storage | ✅ **Implemented** | `commands/add.sh` with pane association options |
 | New `list` command with metadata display | ✅ **Implemented** | `commands/list.sh` with filters (`--active`, `--dismissed`, `--level`, `--pane`) |
 | New `dismiss` command for individual notifications | ✅ **Implemented** | `commands/dismiss.sh` supports individual and `--all` |
-| Configuration system with config.sh template | ✅ **Implemented** | `lib/config.sh` with sample config and `config_load()` |
+| Configuration system with config.sh template | ✅ **Implemented** | `legacy/config.sh` with sample config and `config_load()` |
 | Migration script from environment variables | ❌ **Missing** | No migration from `TMUX_INTRAY_ITEMS` to TSV storage |
 | Comprehensive test suite | ✅ **Implemented** | `tests/storage.bats`, `tests/commands/*.bats` |
 
@@ -111,7 +111,7 @@ The tmux-intray project has implemented **significant portions** of the planned 
 ### Core Libraries
 - `lib/storage.sh`: TSV storage with locking (Phase 1)
 - `lib/core.sh`: Context capture, pane validation, jump (Phase 2)
-- `lib/config.sh`: Configuration loading (Phase 1)
+- `legacy/config.sh`: Configuration loading (Phase 1)
 - `lib/colors.sh`: Color utilities
 
 ### Commands
@@ -150,7 +150,7 @@ The tmux-intray project has implemented **significant portions** of the planned 
    - Schedule via cron or run on command
 
 ### Medium-term Enhancements
-3. **Add hooks system** (`lib/hooks.sh`)
+3. **Add hooks system** (`legacy/hooks.sh`)
    - Pre/post notification hooks
    - Configuration for script paths
    - Environment variables for hook context

--- a/legacy/config.sh
+++ b/legacy/config.sh
@@ -2,11 +2,11 @@
 # Configuration management for tmux-intray
 
 # Load core utilities
-# Determine absolute directory of this script
-_TMUX_INTRAY_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=./colors.sh disable=SC1091
+# Determine absolute directories
+_TMUX_INTRAY_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../lib/colors.sh disable=SC1091
 # The sourced file exists at runtime but ShellCheck can't resolve it due to relative path/context.
-source "$_TMUX_INTRAY_LIB_DIR/colors.sh"
+source "$_TMUX_INTRAY_LIB_DIR/lib/colors.sh"
 
 # Default configuration values
 TMUX_INTRAY_STATE_DIR="${TMUX_INTRAY_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/tmux-intray}"

--- a/legacy/hooks.sh
+++ b/legacy/hooks.sh
@@ -2,12 +2,13 @@
 # Hook system for tmux-intray
 
 # Load core utilities
-# Determine absolute directory of this script
-_TMUX_INTRAY_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=./colors.sh disable=SC1091
-source "$_TMUX_INTRAY_LIB_DIR/colors.sh"
+# Determine absolute directories
+_TMUX_INTRAY_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+_TMUX_INTRAY_LEGACY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/colors.sh disable=SC1091
+source "$_TMUX_INTRAY_LIB_DIR/lib/colors.sh"
 # shellcheck source=./config.sh disable=SC1091
-source "$_TMUX_INTRAY_LIB_DIR/config.sh"
+source "$_TMUX_INTRAY_LEGACY_DIR/config.sh"
 
 # Default configuration values
 TMUX_INTRAY_HOOKS_ENABLED="${TMUX_INTRAY_HOOKS_ENABLED:-1}"

--- a/lib/storage.sh
+++ b/lib/storage.sh
@@ -8,8 +8,18 @@ _TMUX_INTRAY_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=./colors.sh disable=SC1091
 # The sourced file exists at runtime but ShellCheck can't resolve it due to relative path/context.
 source "$_TMUX_INTRAY_LIB_DIR/colors.sh"
-# shellcheck source=./hooks.sh disable=SC1091
-source "$_TMUX_INTRAY_LIB_DIR/hooks.sh"
+
+# Stub functions for hooks (disabled in Go migration)
+hooks_init() {
+    # No-op - hooks system disabled in Go migration
+    debug "Hooks system disabled in Go migration"
+}
+
+hooks_run() {
+    # No-op - hooks system disabled in Go migration
+    debug "Hooks disabled: $1"
+    return 0
+}
 
 # Default directories
 TMUX_INTRAY_STATE_DIR="${TMUX_INTRAY_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/tmux-intray}"

--- a/scripts/status-panel.sh
+++ b/scripts/status-panel.sh
@@ -8,9 +8,9 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 # shellcheck source=../lib/colors.sh disable=SC1091
 # The sourced file exists at runtime but ShellCheck can't resolve it due to relative path/context.
 source "$PROJECT_ROOT/lib/colors.sh"
-# shellcheck source=../lib/core.sh disable=SC1091
+# shellcheck source=../lib/storage.sh disable=SC1091
 # The sourced file exists at runtime but ShellCheck can't resolve it due to relative path/context.
-source "$PROJECT_ROOT/lib/core.sh"
+source "$PROJECT_ROOT/lib/storage.sh"
 
 # Default configuration
 TMUX_INTRAY_STATUS_FORMAT="${TMUX_INTRAY_STATUS_FORMAT:-compact}"

--- a/tests/hooks.bats
+++ b/tests/hooks.bats
@@ -36,8 +36,8 @@ EOF
 }
 
 @test "hooks_run with no hooks directory returns success" {
-    # shellcheck source=../lib/hooks.sh
-    source "$BATS_TEST_DIRNAME/../lib/hooks.sh"
+    # shellcheck source=../legacy/hooks.sh
+    source "$BATS_TEST_DIRNAME/../legacy/hooks.sh"
 
     run hooks_run "pre-add"
     [ "$status" -eq 0 ]
@@ -46,8 +46,8 @@ EOF
 
 @test "hooks_run with empty hooks directory returns success" {
     mkdir -p "$TMUX_INTRAY_CONFIG_DIR/hooks/pre-add"
-    # shellcheck source=../lib/hooks.sh
-    source "$BATS_TEST_DIRNAME/../lib/hooks.sh"
+    # shellcheck source=../legacy/hooks.sh
+    source "$BATS_TEST_DIRNAME/../legacy/hooks.sh"
 
     run hooks_run "pre-add"
     [ "$status" -eq 0 ]
@@ -57,8 +57,8 @@ EOF
 @test "hooks_run executes a single hook script" {
     _create_hook_script "pre-add" "01-test.sh" "echo 'Hello from hook'"
 
-    # shellcheck source=../lib/hooks.sh
-    source "$BATS_TEST_DIRNAME/../lib/hooks.sh"
+    # shellcheck source=../legacy/hooks.sh
+    source "$BATS_TEST_DIRNAME/../legacy/hooks.sh"
 
     run hooks_run "pre-add"
     [ "$status" -eq 0 ]
@@ -70,8 +70,8 @@ EOF
     # shellcheck disable=SC2016
     _create_hook_script "pre-add" "env.sh" 'echo "MESSAGE=$MESSAGE"'
 
-    # shellcheck source=../lib/hooks.sh
-    source "$BATS_TEST_DIRNAME/../lib/hooks.sh"
+    # shellcheck source=../legacy/hooks.sh
+    source "$BATS_TEST_DIRNAME/../legacy/hooks.sh"
 
     run hooks_run "pre-add" "MESSAGE=test value"
     [ "$status" -eq 0 ]
@@ -82,8 +82,8 @@ EOF
     _create_hook_script "pre-add" "fail.sh" "exit 1"
     export TMUX_INTRAY_HOOKS_FAILURE_MODE="ignore"
 
-    # shellcheck source=../lib/hooks.sh
-    source "$BATS_TEST_DIRNAME/../lib/hooks.sh"
+    # shellcheck source=../legacy/hooks.sh
+    source "$BATS_TEST_DIRNAME/../legacy/hooks.sh"
 
     run hooks_run "pre-add"
     [ "$status" -eq 0 ]
@@ -96,8 +96,8 @@ EOF
     _create_hook_script "pre-add" "fail.sh" "exit 1"
     export TMUX_INTRAY_HOOKS_FAILURE_MODE="warn"
 
-    # shellcheck source=../lib/hooks.sh
-    source "$BATS_TEST_DIRNAME/../lib/hooks.sh"
+    # shellcheck source=../legacy/hooks.sh
+    source "$BATS_TEST_DIRNAME/../legacy/hooks.sh"
 
     run hooks_run "pre-add"
     [ "$status" -eq 0 ]
@@ -109,8 +109,8 @@ EOF
     _create_hook_script "pre-add" "fail.sh" "exit 1"
     export TMUX_INTRAY_HOOKS_FAILURE_MODE="abort"
 
-    # shellcheck source=../lib/hooks.sh
-    source "$BATS_TEST_DIRNAME/../lib/hooks.sh"
+    # shellcheck source=../legacy/hooks.sh
+    source "$BATS_TEST_DIRNAME/../legacy/hooks.sh"
 
     run hooks_run "pre-add"
     [ "$status" -eq 1 ]
@@ -122,8 +122,8 @@ EOF
     _create_hook_script "pre-add" "02-second.sh" "echo 'second'"
     _create_hook_script "pre-add" "01-first.sh" "echo 'first'"
 
-    # shellcheck source=../lib/hooks.sh
-    source "$BATS_TEST_DIRNAME/../lib/hooks.sh"
+    # shellcheck source=../legacy/hooks.sh
+    source "$BATS_TEST_DIRNAME/../legacy/hooks.sh"
 
     run hooks_run "pre-add"
     [ "$status" -eq 0 ]
@@ -141,8 +141,8 @@ EOF
     _create_hook_script "pre-add" "test.sh" "echo 'executed'"
     export TMUX_INTRAY_HOOKS_ENABLED_pre_add=0
 
-    # shellcheck source=../lib/hooks.sh
-    source "$BATS_TEST_DIRNAME/../lib/hooks.sh"
+    # shellcheck source=../legacy/hooks.sh
+    source "$BATS_TEST_DIRNAME/../legacy/hooks.sh"
 
     run hooks_run "pre-add"
     [ "$status" -eq 0 ]
@@ -153,8 +153,8 @@ EOF
     _create_hook_script "pre-add" "test.sh" "echo 'executed'"
     export TMUX_INTRAY_HOOKS_ENABLED=0
 
-    # shellcheck source=../lib/hooks.sh
-    source "$BATS_TEST_DIRNAME/../lib/hooks.sh"
+    # shellcheck source=../legacy/hooks.sh
+    source "$BATS_TEST_DIRNAME/../legacy/hooks.sh"
 
     run hooks_run "pre-add"
     [ "$status" -eq 0 ]
@@ -165,8 +165,8 @@ EOF
     _create_hook_script "pre-add" "sleep.sh" "sleep 0.1; echo 'done'"
     export TMUX_INTRAY_HOOKS_ASYNC=1
 
-    # shellcheck source=../lib/hooks.sh
-    source "$BATS_TEST_DIRNAME/../lib/hooks.sh"
+    # shellcheck source=../legacy/hooks.sh
+    source "$BATS_TEST_DIRNAME/../legacy/hooks.sh"
 
     run hooks_run "pre-add"
     [ "$status" -eq 0 ]


### PR DESCRIPTION
- Move config.sh and hooks.sh from lib/ to legacy/ directory
- Update storage.sh to remove dependency on hooks.sh and add stub functions
- Update status-panel.sh to source storage.sh instead of core.sh
- Update tests/hooks.bats to source hooks.sh from legacy/ directory
- Update documentation to reflect new location of legacy files
- These changes clean up the codebase after migrating to Go implementation