### PR TITLE
fix: check and return os.MkdirAll error in hooks.Init()

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,7 +52,9 @@ func handleCommandError(cmd *cobra.Command, args []string) error {
 // This is called by main.main(). It only needs to happen once to the RootCmd.
 func ExecuteOriginal() error {
 	defer hooks.WaitForPendingHooks()
-	hooks.Init()
+	if err := hooks.Init(); err != nil {
+		return err
+	}
 	return RootCmd.Execute()
 }
 
@@ -80,7 +82,9 @@ func init() {
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() error {
 	defer hooks.WaitForPendingHooks()
-	hooks.Init()
+	if err := hooks.Init(); err != nil {
+		return err
+	}
 
 	args := os.Args[1:]
 

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -53,18 +53,22 @@ func getManager() *hookManager {
 }
 
 // Init initializes the hooks subsystem.
-func Init() {
+func Init() error {
 	config.Load()
 	m := getManager()
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.initialized {
-		return
+		return nil
 	}
 	// Ensure hooks directory exists
 	dir := getHooksDir()
-	os.MkdirAll(dir, 0755)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		colors.Error(fmt.Sprintf("failed to create hooks directory %s: %v", dir, err))
+		return fmt.Errorf("failed to create hooks directory %s: %w", dir, err)
+	}
 	m.initialized = true
+	return nil
 }
 
 // getHooksDir returns the hooks directory path.

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -12,7 +13,8 @@ import (
 
 func TestInitAndRunNoPanic(t *testing.T) {
 	require.NotPanics(t, func() {
-		Init()
+		err := Init()
+		require.NoError(t, err)
 		Run("pre-add", "FOO=bar")
 	})
 }
@@ -301,4 +303,29 @@ func TestAsyncHookContextCancellation(t *testing.T) {
 
 	// Should complete within timeout + overhead
 	require.Less(t, duration, 2*time.Second)
+}
+
+func TestInitDirectoryCreationFailure(t *testing.T) {
+	// Reset manager state to allow testing
+	manager = nil
+	once = sync.Once{}
+
+	// Create a temporary directory structure with a read-only parent
+	tmpDir := t.TempDir()
+	roDir := filepath.Join(tmpDir, "readonly")
+	require.NoError(t, os.MkdirAll(roDir, 0755))
+	// Make the directory read-only
+	require.NoError(t, os.Chmod(roDir, 0444))
+	defer os.Chmod(roDir, 0755) // Restore permissions for cleanup
+
+	// Set hooks directory to be inside the read-only directory
+	oldDir := os.Getenv("TMUX_INTRAY_HOOKS_DIR")
+	defer os.Setenv("TMUX_INTRAY_HOOKS_DIR", oldDir)
+	hooksDir := filepath.Join(roDir, "hooks")
+	os.Setenv("TMUX_INTRAY_HOOKS_DIR", hooksDir)
+
+	// Attempt to initialize hooks - should fail
+	err := Init()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to create hooks directory")
 }

--- a/internal/tmuxintray/tmuxintray.go
+++ b/internal/tmuxintray/tmuxintray.go
@@ -2,6 +2,7 @@
 package tmuxintray
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/cristianoliveira/tmux-intray/internal/colors"
@@ -41,7 +42,9 @@ func Init() error {
 	storage.Init()
 
 	// Initialize hooks subsystem
-	hooks.Init()
+	if err := hooks.Init(); err != nil {
+		return fmt.Errorf("hooks initialization failed: %w", err)
+	}
 
 	// TODO: verify initialization
 	return nil


### PR DESCRIPTION
- Changed hooks.Init() to return error instead of silently ignoring it
- Added error logging with context using colors.Error()
- Wrapped error with directory path for better debugging
- Updated all callers (cmd/root.go, internal/tmuxintray) to handle error
- Added TestInitDirectoryCreationFailure to verify error handling

Fixes Tiger Style violations:
- Fail-Fast: Errors are no longer silently ignored
- NASA Rule 7: Return values are now properly checked

Acceptance criteria met:
✓ Check os.MkdirAll() error
✓ Log error with directory path
✓ Return error from Init()
✓ Add test for directory creation failure

Related: tmux-intray-23hk