### PR TITLE
fix: return error when post-add hook fails in abort mode

### DIFF
--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -217,8 +217,10 @@ func AddNotification(message, timestamp, session, window, pane, paneCreated, lev
 
 	// Run post-add hooks
 	if err := hooks.Run("post-add", envVars...); err != nil {
-		colors.Error(fmt.Sprintf("post-add hook aborted: %v", err))
-		// Still return ID because notification was added, but log the error
+		colors.Error(fmt.Sprintf("post-add hook failed: %v", err))
+		// Return error because post-processing failed in abort mode
+		// The notification was added but post-add hooks are critical for cleanup/state
+		return strconv.Itoa(id), fmt.Errorf("post-add hook failed: %w", err)
 	}
 
 	// Return ID as string


### PR DESCRIPTION
Fixed inconsistent state where AddNotification() returned success even when post-add hooks failed in abort mode. The function now properly returns an error for abort mode, while still returning the notification ID for partial success cases.

Added comprehensive tests for abort, warn, and ignore failure modes.

Fixes: tmux-intray-o22e