### PR TITLE
chore: log config errors instead of silent failure

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -121,6 +121,7 @@ func loadFromFile() {
 
 	data, err := os.ReadFile(configPath)
 	if err != nil {
+		colors.Debug(fmt.Sprintf("unable to read config file %s: %v", configPath, err))
 		return
 	}
 
@@ -137,6 +138,7 @@ func loadFromFile() {
 		return
 	}
 	if err != nil {
+		colors.Warning(fmt.Sprintf("unable to parse config file %s: %v", configPath, err))
 		return
 	}
 
@@ -348,11 +350,14 @@ func createSampleConfig() {
 
 	data, err := toml.Marshal(typed)
 	if err != nil {
+		colors.Warning(fmt.Sprintf("unable to marshal sample config: %v", err))
 		return
 	}
 	// Add a header comment
 	header := "# tmux-intray configuration\n# This file is in TOML format.\n# Uncomment and edit values as needed.\n\n"
-	os.WriteFile(samplePath, append([]byte(header), data...), 0644)
+	if err := os.WriteFile(samplePath, append([]byte(header), data...), 0644); err != nil {
+		colors.Warning(fmt.Sprintf("unable to write sample config to %s: %v", samplePath, err))
+	}
 }
 
 // Get returns a configuration value or default.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,11 +1,13 @@
 package config
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/cristianoliveira/tmux-intray/internal/colors"
 	"github.com/pelletier/go-toml/v2"
 	"github.com/stretchr/testify/require"
 )
@@ -275,4 +277,213 @@ func TestXdgDefaults(t *testing.T) {
 	require.Equal(t, expectedStateDir, Get("state_dir", ""))
 	// hooks_dir should be config_dir/hooks
 	require.Equal(t, filepath.Join(expectedConfigDir, "hooks"), Get("hooks_dir", ""))
+}
+
+// Test that a non-existent config file is handled gracefully and logged at debug level.
+func TestConfigFileNotFound(t *testing.T) {
+	reset()
+	tmpDir := t.TempDir()
+	nonExistentPath := filepath.Join(tmpDir, "does_not_exist.toml")
+
+	t.Setenv("TMUX_INTRAY_CONFIG_PATH", nonExistentPath)
+	// Enable debug output to capture debug messages.
+	colors.SetDebug(true)
+	defer colors.SetDebug(false)
+
+	// Capture stderr to verify debug logging.
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	Load()
+
+	// Close writer and restore stderr.
+	w.Close()
+	os.Stderr = oldStderr
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	// Should contain debug message about file not found.
+	require.Contains(t, output, "Debug:")
+	require.Contains(t, output, "unable to read config file")
+	require.Contains(t, output, nonExistentPath)
+
+	// Defaults should still be loaded.
+	require.Equal(t, "1000", Get("max_notifications", ""))
+}
+
+// Test that a malformed config file is handled gracefully and logged at warning level.
+func TestConfigFileMalformed(t *testing.T) {
+	reset()
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.toml")
+
+	// Write malformed TOML.
+	err := os.WriteFile(configPath, []byte("invalid toml content [unclosed"), 0644)
+	require.NoError(t, err)
+
+	t.Setenv("TMUX_INTRAY_CONFIG_PATH", configPath)
+
+	// Capture stderr to verify warning logging.
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	Load()
+
+	// Close writer and restore stderr.
+	w.Close()
+	os.Stderr = oldStderr
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	// Should contain warning message about parse error.
+	require.Contains(t, output, "Warning:")
+	require.Contains(t, output, "unable to parse config file")
+	require.Contains(t, output, configPath)
+
+	// Defaults should still be loaded.
+	require.Equal(t, "1000", Get("max_notifications", ""))
+}
+
+// Test that malformed JSON is logged at warning level.
+func TestConfigFileMalformedJSON(t *testing.T) {
+	reset()
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.json")
+
+	// Write malformed JSON.
+	err := os.WriteFile(configPath, []byte(`{"invalid": json}`), 0644)
+	require.NoError(t, err)
+
+	t.Setenv("TMUX_INTRAY_CONFIG_PATH", configPath)
+
+	// Capture stderr to verify warning logging.
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	Load()
+
+	// Close writer and restore stderr.
+	w.Close()
+	os.Stderr = oldStderr
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	// Should contain warning message about parse error.
+	require.Contains(t, output, "Warning:")
+	require.Contains(t, output, "unable to parse config file")
+	require.Contains(t, output, configPath)
+}
+
+// Test that malformed YAML is logged at warning level.
+func TestConfigFileMalformedYAML(t *testing.T) {
+	reset()
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	// Write malformed YAML (invalid indentation).
+	err := os.WriteFile(configPath, []byte("invalid:\n  - item1\n item2"), 0644)
+	require.NoError(t, err)
+
+	t.Setenv("TMUX_INTRAY_CONFIG_PATH", configPath)
+
+	// Capture stderr to verify warning logging.
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	Load()
+
+	// Close writer and restore stderr.
+	w.Close()
+	os.Stderr = oldStderr
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	// Should contain warning message about parse error.
+	require.Contains(t, output, "Warning:")
+	require.Contains(t, output, "unable to parse config file")
+	require.Contains(t, output, configPath)
+}
+
+// Test that read errors (permission denied) are logged at debug level.
+func TestConfigFileReadError(t *testing.T) {
+	reset()
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.toml")
+
+	// Create file with no read permissions.
+	err := os.WriteFile(configPath, []byte("max_notifications = 200"), 0000)
+	require.NoError(t, err)
+
+	t.Setenv("TMUX_INTRAY_CONFIG_PATH", configPath)
+	// Enable debug output to capture debug messages.
+	colors.SetDebug(true)
+	defer colors.SetDebug(false)
+
+	// Capture stderr to verify debug logging.
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	Load()
+
+	// Close writer and restore stderr.
+	w.Close()
+	os.Stderr = oldStderr
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	// Should contain debug message about read error.
+	require.Contains(t, output, "Debug:")
+	require.Contains(t, output, "unable to read config file")
+	require.Contains(t, output, configPath)
+
+	// Defaults should still be loaded.
+	require.Equal(t, "1000", Get("max_notifications", ""))
+}
+
+// Test that debug messages are not shown when TMUX_INTRAY_DEBUG is not set.
+func TestConfigFileNotFoundNoDebug(t *testing.T) {
+	reset()
+	tmpDir := t.TempDir()
+	nonExistentPath := filepath.Join(tmpDir, "does_not_exist.toml")
+
+	t.Setenv("TMUX_INTRAY_CONFIG_PATH", nonExistentPath)
+	// Ensure debug is not enabled.
+	t.Setenv("TMUX_INTRAY_DEBUG", "")
+
+	// Capture stderr to verify no debug logging.
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	Load()
+
+	// Close writer and restore stderr.
+	w.Close()
+	os.Stderr = oldStderr
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	// Should NOT contain debug message.
+	require.NotContains(t, output, "Debug:")
+	require.NotContains(t, output, "unable to read config file")
+
+	// Defaults should still be loaded.
+	require.Equal(t, "1000", Get("max_notifications", ""))
 }


### PR DESCRIPTION
Configuration file errors were previously silently ignored, making debugging difficult. Errors are now logged at appropriate levels:

- File read errors → colors.Debug() (shown with TMUX_INTRAY_DEBUG)
- Parse/unmarshal errors → colors.Warning() (always shown)
- Marshal/write errors → colors.Warning() (rare system errors)

Added comprehensive test coverage:
- TestConfigFileNotFound
- TestConfigFileMalformed
- TestConfigFileMalformedJSON
- TestConfigFileMalformedYAML
- TestConfigFileReadError
- TestConfigFileNotFoundNoDebug

Fixes: tmux-intray-r2g6