### PR TITLE
refactor(core): migrate to TmuxClient dependency injection

### DIFF
--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -51,7 +51,7 @@ func GetTrayItems(stateFilter string) string {
 // AddTrayItem adds a tray item.
 // If session, window, pane are empty and noAuto is false, current tmux context is used.
 // Returns the notification ID or an error if validation fails.
-func AddTrayItem(item, session, window, pane, paneCreated string, noAuto bool, level string) (string, error) {
+func (c *Core) AddTrayItem(item, session, window, pane, paneCreated string, noAuto bool, level string) (string, error) {
 	// Treat empty/whitespace context same as not provided for resilience
 	// This handles cases where plugin passes empty strings as flags
 	session = strings.TrimSpace(session)
@@ -60,7 +60,7 @@ func AddTrayItem(item, session, window, pane, paneCreated string, noAuto bool, l
 
 	// If auto context allowed and session/window/pane empty, get current tmux context
 	if !noAuto && session == "" && window == "" && pane == "" {
-		ctx := GetCurrentTmuxContext()
+		ctx := c.GetCurrentTmuxContext()
 		if ctx.SessionID != "" {
 			session = ctx.SessionID
 			window = ctx.WindowID
@@ -80,27 +80,42 @@ func AddTrayItem(item, session, window, pane, paneCreated string, noAuto bool, l
 	return id, nil
 }
 
+// AddTrayItem adds a tray item using the default client.
+func AddTrayItem(item, session, window, pane, paneCreated string, noAuto bool, level string) (string, error) {
+	return defaultCore.AddTrayItem(item, session, window, pane, paneCreated, noAuto, level)
+}
+
 // ClearTrayItems dismisses all active tray items.
 func ClearTrayItems() error {
 	return storage.DismissAll()
 }
 
 // GetVisibility returns the visibility state as "0" or "1".
+func (c *Core) GetVisibility() string {
+	return c.GetTmuxVisibility()
+}
+
+// GetVisibility returns the visibility state as "0" or "1" using the default client.
 func GetVisibility() string {
-	return GetTmuxVisibility()
+	return defaultCore.GetVisibility()
 }
 
 // SetVisibility sets the visibility state.
-func SetVisibility(visible bool) error {
+func (c *Core) SetVisibility(visible bool) error {
 	value := "0"
 	if visible {
 		value = "1"
 	}
-	success := SetTmuxVisibility(value)
+	success := c.SetTmuxVisibility(value)
 	if !success {
 		return ErrTmuxOperationFailed
 	}
 	return nil
+}
+
+// SetVisibility sets the visibility state using the default client.
+func SetVisibility(visible bool) error {
+	return defaultCore.SetVisibility(visible)
 }
 
 // Helper functions copied from storage package (since they're not exported)

--- a/internal/core/core_test.go
+++ b/internal/core/core_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/cristianoliveira/tmux-intray/internal/colors"
 	"github.com/cristianoliveira/tmux-intray/internal/storage"
+	"github.com/cristianoliveira/tmux-intray/internal/tmux"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,10 +20,6 @@ func TestCore(t *testing.T) {
 	// Initialize storage once
 	storage.Init()
 
-	// Backup original tmuxRunner
-	origRunner := tmuxRunner
-	defer func() { tmuxRunner = origRunner }()
-
 	// Helper to clear all notifications before each subtest
 	clearNotifications := func() {
 		_ = storage.DismissAll()
@@ -30,16 +27,14 @@ func TestCore(t *testing.T) {
 
 	t.Run("GetTrayItems", func(t *testing.T) {
 		clearNotifications()
-		// Mock tmuxRunner to simulate tmux not running
-		tmuxRunner = func(args ...string) (string, string, error) {
-			return "", "tmux not running", os.ErrNotExist
-		}
+		// Use default core (tmux not needed for this test)
+		c := NewCore(nil)
 
 		// Add notifications with explicit session/window/pane
-		id1, err := AddTrayItem("message 1", "$1", "%1", "@1", "123456", true, "info")
+		id1, err := c.AddTrayItem("message 1", "$1", "%1", "@1", "123456", true, "info")
 		require.NoError(t, err)
 		require.NotEmpty(t, id1)
-		id2, err := AddTrayItem("message 2", "$2", "%2", "@2", "123457", true, "warning")
+		id2, err := c.AddTrayItem("message 2", "$2", "%2", "@2", "123457", true, "warning")
 		require.NoError(t, err)
 		require.NotEmpty(t, id2)
 
@@ -57,29 +52,31 @@ func TestCore(t *testing.T) {
 
 	t.Run("AddTrayItemAutoContext", func(t *testing.T) {
 		clearNotifications()
-		// Mock tmuxRunner to return a known context
-		tmuxRunner = func(args ...string) (string, string, error) {
-			if len(args) >= 3 && args[0] == "display" && args[1] == "-p" {
-				return "$session %window @pane 1748987643", "", nil
-			}
-			return "", "", os.ErrNotExist
-		}
+		// Mock tmux client to return a known context
+		mockClient := new(tmux.MockClient)
+		mockClient.On("GetCurrentContext").Return(tmux.TmuxContext{
+			SessionID: "$session",
+			WindowID:  "%window",
+			PaneID:    "@pane",
+			PanePID:   "1748987643",
+		}, nil).Once()
+		c := NewCore(mockClient)
 
-		id, err := AddTrayItem("auto message", "", "", "", "", false, "info")
+		id, err := c.AddTrayItem("auto message", "", "", "", "", false, "info")
 		require.NoError(t, err)
 		require.NotEmpty(t, id)
 		// Verify item added (message appears)
 		items := GetTrayItems("active")
 		require.Contains(t, items, "auto message")
+		mockClient.AssertExpectations(t)
 	})
 
 	t.Run("AddTrayItemNoAuto", func(t *testing.T) {
 		clearNotifications()
-		// tmuxRunner will fail, but noAuto true means we don't call it
-		tmuxRunner = func(args ...string) (string, string, error) {
-			return "", "tmux not running", os.ErrNotExist
-		}
-		id, err := AddTrayItem("manual message", "$s", "%w", "@p", "123", true, "error")
+		// tmux client will fail, but noAuto true means we don't call it
+		mockClient := new(tmux.MockClient)
+		c := NewCore(mockClient)
+		id, err := c.AddTrayItem("manual message", "$s", "%w", "@p", "123", true, "error")
 		require.NoError(t, err)
 		require.NotEmpty(t, id)
 		items := GetTrayItems("active")
@@ -88,13 +85,12 @@ func TestCore(t *testing.T) {
 
 	t.Run("ClearTrayItems", func(t *testing.T) {
 		clearNotifications()
-		tmuxRunner = func(args ...string) (string, string, error) {
-			return "", "tmux not running", os.ErrNotExist
-		}
+		// Use default core
+		c := NewCore(nil)
 
-		_, err := AddTrayItem("msg1", "$1", "%1", "@1", "123", true, "info")
+		_, err := c.AddTrayItem("msg1", "$1", "%1", "@1", "123", true, "info")
 		require.NoError(t, err)
-		_, err = AddTrayItem("msg2", "$2", "%2", "@2", "456", true, "warning")
+		_, err = c.AddTrayItem("msg2", "$2", "%2", "@2", "456", true, "warning")
 		require.NoError(t, err)
 
 		err = ClearTrayItems()
@@ -106,46 +102,39 @@ func TestCore(t *testing.T) {
 
 	t.Run("Visibility", func(t *testing.T) {
 		clearNotifications()
-		// Mock tmuxRunner for visibility operations
-		var lastArgs []string
-		tmuxRunner = func(args ...string) (string, string, error) {
-			lastArgs = args
-			if args[0] == "show-environment" && len(args) >= 3 && args[2] == "TMUX_INTRAY_VISIBLE" {
-				return "TMUX_INTRAY_VISIBLE=1", "", nil
-			}
-			return "", "", nil
-		}
+		// Mock tmux client for visibility operations
+		mockClient := new(tmux.MockClient)
+		mockClient.On("GetEnvironment", "TMUX_INTRAY_VISIBLE").Return("1", nil).Once()
+		c := NewCore(mockClient)
 
-		visible := GetVisibility()
+		visible := c.GetVisibility()
 		require.Equal(t, "1", visible)
+		mockClient.AssertExpectations(t)
 
 		// SetVisibility with true should call set-environment with "1"
-		lastArgs = nil
-		tmuxRunner = func(args ...string) (string, string, error) {
-			lastArgs = args
-			return "", "", nil
-		}
-		err := SetVisibility(true)
+		mockClient = new(tmux.MockClient)
+		mockClient.On("SetEnvironment", "TMUX_INTRAY_VISIBLE", "1").Return(nil).Once()
+		c = NewCore(mockClient)
+		err := c.SetVisibility(true)
 		require.NoError(t, err)
-		require.Equal(t, []string{"set-environment", "-g", "TMUX_INTRAY_VISIBLE", "1"}, lastArgs)
+		mockClient.AssertExpectations(t)
 
 		// SetVisibility with false should set "0"
-		lastArgs = nil
-		tmuxRunner = func(args ...string) (string, string, error) {
-			lastArgs = args
-			return "", "", nil
-		}
-		err = SetVisibility(false)
+		mockClient = new(tmux.MockClient)
+		mockClient.On("SetEnvironment", "TMUX_INTRAY_VISIBLE", "0").Return(nil).Once()
+		c = NewCore(mockClient)
+		err = c.SetVisibility(false)
 		require.NoError(t, err)
-		require.Equal(t, []string{"set-environment", "-g", "TMUX_INTRAY_VISIBLE", "0"}, lastArgs)
+		mockClient.AssertExpectations(t)
 
 		// Simulate tmux failure
-		tmuxRunner = func(args ...string) (string, string, error) {
-			return "", "error", os.ErrInvalid
-		}
-		err = SetVisibility(true)
+		mockClient = new(tmux.MockClient)
+		mockClient.On("SetEnvironment", "TMUX_INTRAY_VISIBLE", "1").Return(tmux.ErrTmuxNotRunning).Once()
+		c = NewCore(mockClient)
+		err = c.SetVisibility(true)
 		require.Error(t, err)
 		require.Equal(t, ErrTmuxOperationFailed, err)
+		mockClient.AssertExpectations(t)
 	})
 
 	t.Run("escapeMessage", func(t *testing.T) {

--- a/internal/core/tmux.go
+++ b/internal/core/tmux.go
@@ -3,10 +3,9 @@ package core
 
 import (
 	"fmt"
-	"os/exec"
-	"strings"
 
 	"github.com/cristianoliveira/tmux-intray/internal/colors"
+	"github.com/cristianoliveira/tmux-intray/internal/tmux"
 )
 
 // TmuxContext captures the current tmux session/window/pane context.
@@ -17,100 +16,73 @@ type TmuxContext struct {
 	PaneCreated string
 }
 
-// tmuxRunner is a variable that can be replaced for testing.
-var tmuxRunner = func(args ...string) (string, string, error) {
-	cmd := exec.Command("tmux", args...)
-	var stdout, stderr strings.Builder
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	err := cmd.Run()
-	return stdout.String(), stderr.String(), err
+// Core provides core tmux interaction functionality with injected TmuxClient.
+type Core struct {
+	client tmux.TmuxClient
 }
 
+// NewCore creates a new Core instance with the given TmuxClient.
+// If client is nil, a default client will be created.
+func NewCore(client tmux.TmuxClient) *Core {
+	if client == nil {
+		client = tmux.NewDefaultClient()
+	}
+	return &Core{client: client}
+}
+
+// defaultCore is the default instance for backward compatibility.
+var defaultCore = NewCore(nil)
+
 // EnsureTmuxRunning verifies that tmux is running.
-func EnsureTmuxRunning() bool {
-	_, stderr, err := tmuxRunner("has-session")
+func (c *Core) EnsureTmuxRunning() bool {
+	running, err := c.client.HasSession()
 	if err != nil {
 		colors.Debug("tmux has-session failed: " + err.Error())
-		if stderr != "" {
-			colors.Debug("stderr: " + stderr)
-		}
 		return false
 	}
-	return true
+	return running
+}
+
+// EnsureTmuxRunning verifies that tmux is running using the default client.
+func EnsureTmuxRunning() bool {
+	return defaultCore.EnsureTmuxRunning()
 }
 
 // GetCurrentTmuxContext returns the current tmux context.
-func GetCurrentTmuxContext() TmuxContext {
-	format := "#{session_id} #{window_id} #{pane_id} #{pane_pid}"
-	stdout, stderr, err := tmuxRunner("display", "-p", format)
+func (c *Core) GetCurrentTmuxContext() TmuxContext {
+	ctx, err := c.client.GetCurrentContext()
 	if err != nil {
 		colors.Error("Failed to get tmux context: " + err.Error())
-		if stderr != "" {
-			colors.Debug("stderr: " + stderr)
-		}
 		return TmuxContext{}
 	}
 
-	// Trim whitespace from the output
-	stdout = strings.TrimSpace(stdout)
-
-	// Split by space - tmux format string produces 4 parts
-	// Format: #{session_id} #{window_id} #{pane_id} #{pane_pid}
-	parts := strings.Split(stdout, " ")
-
-	// Filter out empty strings that might result from multiple spaces
-	var filteredParts []string
-	for _, part := range parts {
-		if part != "" {
-			filteredParts = append(filteredParts, part)
-		}
+	// Convert tmux.TmuxContext to core.TmuxContext
+	return TmuxContext{
+		SessionID:   ctx.SessionID,
+		WindowID:    ctx.WindowID,
+		PaneID:      ctx.PaneID,
+		PaneCreated: ctx.PanePID,
 	}
+}
 
-	// ASSERTION: Check if we have exactly 4 parts (session_id, window_id, pane_id, pane_pid)
-	// All 4 should always be present in tmux (Power of 10 Rule 5)
-	if len(filteredParts) != 4 {
-		colors.Error(fmt.Sprintf("GetCurrentTmuxContext: unexpected format - expected 4 parts, got %d", len(filteredParts)))
-		return TmuxContext{}
-	}
-
-	// ASSERTION: Validate that captured context values are non-empty
-	if filteredParts[0] == "" || filteredParts[1] == "" || filteredParts[2] == "" {
-		colors.Error("GetCurrentTmuxContext: invalid context - session_id, window_id, or pane_id is empty")
-		return TmuxContext{}
-	}
-
-	ctx := TmuxContext{
-		SessionID:   filteredParts[0], // e.g., "$3"
-		WindowID:    filteredParts[1], // e.g., "@16"
-		PaneID:      filteredParts[2], // e.g., "%21"
-		PaneCreated: filteredParts[3], // e.g., "8443" (pane PID)
-	}
-	return ctx
+// GetCurrentTmuxContext returns the current tmux context using the default client.
+func GetCurrentTmuxContext() TmuxContext {
+	return defaultCore.GetCurrentTmuxContext()
 }
 
 // ValidatePaneExists checks if a pane exists.
-func ValidatePaneExists(sessionID, windowID, paneID string) bool {
-	target := sessionID + ":" + windowID
-	stdout, stderr, err := tmuxRunner("list-panes", "-t", target, "-F", "#{pane_id}")
+func (c *Core) ValidatePaneExists(sessionID, windowID, paneID string) bool {
+	exists, err := c.client.ValidatePaneExists(sessionID, windowID, paneID)
 	if err != nil {
 		colors.Debug("tmux list-panes failed: " + err.Error())
-		if stderr != "" {
-			colors.Debug("stderr: " + stderr)
-		}
 		return false
 	}
-	// Each pane ID is on a separate line
-	lines := strings.Split(strings.TrimSpace(stdout), "\n")
-	// Trim paneID input in case it has whitespace
-	paneID = strings.TrimSpace(paneID)
-	for _, line := range lines {
-		// Trim each pane ID from output in case of trailing whitespace
-		if strings.TrimSpace(line) == paneID {
-			return true
-		}
-	}
-	return false
+	return exists
+}
+
+// ValidatePaneExists checks if a pane exists using the default client.
+func ValidatePaneExists(sessionID, windowID, paneID string) bool {
+	return defaultCore.ValidatePaneExists(sessionID, windowID, paneID)
 }
 
 // JumpToPane jumps to a specific pane. It returns true if the jump succeeded
@@ -120,7 +92,7 @@ func ValidatePaneExists(sessionID, windowID, paneID string) bool {
 //   - Pane reference format must be "sessionID:windowID.paneID" (tmux pane target syntax)
 //   - If select-window fails, return false immediately (fail-fast)
 //   - If select-pane fails, return false (don't swallow errors)
-func JumpToPane(sessionID, windowID, paneID string) bool {
+func (c *Core) JumpToPane(sessionID, windowID, paneID string) bool {
 	// ASSERTION: Validate input parameters are non-empty
 	if sessionID == "" || windowID == "" || paneID == "" {
 		colors.Error("JumpToPane: invalid parameters (empty sessionID, windowID, or paneID)")
@@ -128,15 +100,15 @@ func JumpToPane(sessionID, windowID, paneID string) bool {
 	}
 
 	// First validate if the pane exists
-	paneExists := ValidatePaneExists(sessionID, windowID, paneID)
+	paneExists := c.ValidatePaneExists(sessionID, windowID, paneID)
 	colors.Debug(fmt.Sprintf("JumpToPane: pane validation for %s:%s in window %s:%s - exists: %v", sessionID, paneID, sessionID, windowID, paneExists))
 
 	// Select the window (this happens regardless of whether the pane exists)
 	targetWindow := sessionID + ":" + windowID
 	colors.Debug(fmt.Sprintf("JumpToPane: selecting window %s", targetWindow))
-	_, stderr, err := tmuxRunner("select-window", "-t", targetWindow)
+	_, stderr, err := c.client.Run("select-window", "-t", targetWindow)
 	if err != nil {
-		colors.Error("Window " + targetWindow + " does not exist")
+		colors.Error("Window " + targetWindow + " does not exist: " + err.Error())
 		if stderr != "" {
 			colors.Debug("stderr: " + stderr)
 		}
@@ -154,10 +126,10 @@ func JumpToPane(sessionID, windowID, paneID string) bool {
 	// ASSERTION: targetPane must follow tmux pane reference format
 	targetPane := sessionID + ":" + windowID + "." + paneID
 	colors.Debug(fmt.Sprintf("JumpToPane: selecting pane %s", targetPane))
-	_, stderr, err = tmuxRunner("select-pane", "-t", targetPane)
+	_, stderr, err = c.client.Run("select-pane", "-t", targetPane)
 	if err != nil {
 		// Fail-fast: don't swallow errors, return false to indicate failure
-		colors.Error("Failed to select pane " + targetPane)
+		colors.Error("Failed to select pane " + targetPane + ": " + err.Error())
 		if stderr != "" {
 			colors.Debug("stderr: " + stderr)
 		}
@@ -168,36 +140,38 @@ func JumpToPane(sessionID, windowID, paneID string) bool {
 	return true
 }
 
+// JumpToPane jumps to a specific pane using the default client.
+func JumpToPane(sessionID, windowID, paneID string) bool {
+	return defaultCore.JumpToPane(sessionID, windowID, paneID)
+}
+
 // GetTmuxVisibility returns the value of TMUX_INTRAY_VISIBLE global tmux variable.
 // Returns "0" if variable is not set.
-func GetTmuxVisibility() string {
-	stdout, stderr, err := tmuxRunner("show-environment", "-g", "TMUX_INTRAY_VISIBLE")
+func (c *Core) GetTmuxVisibility() string {
+	value, err := c.client.GetEnvironment("TMUX_INTRAY_VISIBLE")
 	if err != nil {
 		colors.Debug("tmux show-environment failed: " + err.Error())
-		if stderr != "" {
-			colors.Debug("stderr: " + stderr)
-		}
 		return "0"
 	}
-	// Output could be "TMUX_INTRAY_VISIBLE=1" or empty line
-	lines := strings.Split(strings.TrimSpace(stdout), "\n")
-	for _, line := range lines {
-		if strings.HasPrefix(line, "TMUX_INTRAY_VISIBLE=") {
-			return strings.TrimPrefix(line, "TMUX_INTRAY_VISIBLE=")
-		}
-	}
-	return "0"
+	return value
+}
+
+// GetTmuxVisibility returns the value of TMUX_INTRAY_VISIBLE global tmux variable using the default client.
+func GetTmuxVisibility() string {
+	return defaultCore.GetTmuxVisibility()
 }
 
 // SetTmuxVisibility sets the TMUX_INTRAY_VISIBLE global tmux variable.
-func SetTmuxVisibility(value string) bool {
-	_, stderr, err := tmuxRunner("set-environment", "-g", "TMUX_INTRAY_VISIBLE", value)
+func (c *Core) SetTmuxVisibility(value string) bool {
+	err := c.client.SetEnvironment("TMUX_INTRAY_VISIBLE", value)
 	if err != nil {
 		colors.Error("Failed to set tmux visibility: " + err.Error())
-		if stderr != "" {
-			colors.Debug("stderr: " + stderr)
-		}
 		return false
 	}
 	return true
+}
+
+// SetTmuxVisibility sets the TMUX_INTRAY_VISIBLE global tmux variable using the default client.
+func SetTmuxVisibility(value string) bool {
+	return defaultCore.SetTmuxVisibility(value)
 }

--- a/internal/core/tmux_test.go
+++ b/internal/core/tmux_test.go
@@ -1,328 +1,180 @@
 package core
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/cristianoliveira/tmux-intray/internal/colors"
+	"github.com/cristianoliveira/tmux-intray/internal/tmux"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTmuxFunctions(t *testing.T) {
-	// Backup original tmuxRunner
-	origRunner := tmuxRunner
-	defer func() { tmuxRunner = origRunner }()
-
 	t.Run("EnsureTmuxRunning", func(t *testing.T) {
+		mockClient := new(tmux.MockClient)
+
 		// Test when tmux is running
-		tmuxRunner = func(args ...string) (string, string, error) {
-			return "has-session", "", nil
-		}
-		result := EnsureTmuxRunning()
-		if !result {
-			t.Error("Expected true when tmux is running")
-		}
+		mockClient.On("HasSession").Return(true, nil).Once()
+		c := NewCore(mockClient)
+		result := c.EnsureTmuxRunning()
+		require.True(t, result)
+		mockClient.AssertExpectations(t)
 
 		// Test when tmux is not running (returns error)
-		tmuxRunner = func(args ...string) (string, string, error) {
-			return "", "", errors.New("exit status 1")
-		}
-		result = EnsureTmuxRunning()
-		if result {
-			t.Error("Expected false when tmux is not running")
-		}
+		mockClient = new(tmux.MockClient)
+		mockClient.On("HasSession").Return(false, tmux.ErrTmuxNotRunning).Once()
+		c = NewCore(mockClient)
+		result = c.EnsureTmuxRunning()
+		require.False(t, result)
+		mockClient.AssertExpectations(t)
 	})
 
 	t.Run("ValidatePaneExists", func(t *testing.T) {
+		mockClient := new(tmux.MockClient)
+
 		// Test when pane exists
-		tmuxRunner = func(args ...string) (string, string, error) {
-			if args[0] == "list-panes" {
-				return "%1\n%2", "", nil
-			}
-			return "", "", nil
-		}
-		result := ValidatePaneExists("1", "1", "%1")
-		if !result {
-			t.Error("Expected true when pane exists")
-		}
+		mockClient.On("ValidatePaneExists", "1", "1", "%1").Return(true, nil).Once()
+		c := NewCore(mockClient)
+		result := c.ValidatePaneExists("1", "1", "%1")
+		require.True(t, result)
+		mockClient.AssertExpectations(t)
 
 		// Test when pane doesn't exist
-		tmuxRunner = func(args ...string) (string, string, error) {
-			if args[0] == "list-panes" {
-				return "%1\n%2", "", nil
-			}
-			return "", "", nil
-		}
-		result = ValidatePaneExists("1", "1", "%999")
-		if result {
-			t.Error("Expected false when pane doesn't exist")
-		}
+		mockClient = new(tmux.MockClient)
+		mockClient.On("ValidatePaneExists", "1", "1", "%999").Return(false, nil).Once()
+		c = NewCore(mockClient)
+		result = c.ValidatePaneExists("1", "1", "%999")
+		require.False(t, result)
+		mockClient.AssertExpectations(t)
 
 		// Test when command fails
-		tmuxRunner = func(args ...string) (string, string, error) {
-			return "", "", errors.New("command failed")
-		}
-		result = ValidatePaneExists("1", "1", "%1")
-		if result {
-			t.Error("Expected false when command fails")
-		}
+		mockClient = new(tmux.MockClient)
+		mockClient.On("ValidatePaneExists", "1", "1", "%1").Return(false, tmux.ErrTmuxNotRunning).Once()
+		c = NewCore(mockClient)
+		result = c.ValidatePaneExists("1", "1", "%1")
+		require.False(t, result)
+		mockClient.AssertExpectations(t)
 	})
 
 	t.Run("JumpToPane", func(t *testing.T) {
 		// Tiger Style: Test successful jump to existing pane
-		// ASSERTION 1: select-window must be called to change the active window
-		// ASSERTION 2: select-pane must be called to highlight the target pane
-		var selectWindowCalled, selectPaneCalled bool
-		tmuxRunner = func(args ...string) (string, string, error) {
-			if args[0] == "list-panes" {
-				return "%1", "", nil
-			} else if args[0] == "select-window" {
-				selectWindowCalled = true
-				return "", "", nil
-			} else if args[0] == "select-pane" {
-				selectPaneCalled = true
-				return "", "", nil
-			}
-			return "", "", nil
-		}
-		result := JumpToPane("$0", "1", "%1")
-		if !result {
-			t.Error("Expected true when jump succeeds")
-		}
-		if !selectWindowCalled {
-			t.Error("Expected select-window to be called")
-		}
-		if !selectPaneCalled {
-			t.Error("Expected select-pane to be called")
-		}
+		mockClient := new(tmux.MockClient)
+		mockClient.On("ValidatePaneExists", "$0", "1", "%1").Return(true, nil).Once()
+		mockClient.On("Run", []string{"select-window", "-t", "$0:1"}).Return("", "", nil).Once()
+		mockClient.On("Run", []string{"select-pane", "-t", "$0:1.%1"}).Return("", "", nil).Once()
+		c := NewCore(mockClient)
+		result := c.JumpToPane("$0", "1", "%1")
+		require.True(t, result)
+		mockClient.AssertExpectations(t)
 
 		// Tiger Style: Test jump to non-existing pane (should fall back to window)
-		// ASSERTION 1: select-window must still be called for fallback to window
-		// ASSERTION 2: select-pane must NOT be called if pane doesn't exist
-		selectWindowCalled = false
-		selectPaneCalled = false
-		tmuxRunner = func(args ...string) (string, string, error) {
-			if args[0] == "list-panes" {
-				return "%2", "", nil // Different pane, so %1 doesn't exist
-			} else if args[0] == "select-window" {
-				selectWindowCalled = true
-				return "", "", nil
-			} else if args[0] == "select-pane" {
-				selectPaneCalled = true
-				return "", "", nil
-			}
-			return "", "", nil
-		}
-		result = JumpToPane("$0", "1", "%1") // Try to jump to %1
-		if !result {
-			t.Error("Expected true when window exists even if pane doesn't")
-		}
-		if !selectWindowCalled {
-			t.Error("Expected select-window to be called even when pane doesn't exist")
-		}
-		if selectPaneCalled {
-			t.Error("Did not expect select-pane to be called when pane doesn't exist")
-		}
+		mockClient = new(tmux.MockClient)
+		mockClient.On("ValidatePaneExists", "$0", "1", "%1").Return(false, nil).Once()
+		mockClient.On("Run", []string{"select-window", "-t", "$0:1"}).Return("", "", nil).Once()
+		c = NewCore(mockClient)
+		result = c.JumpToPane("$0", "1", "%1")
+		require.True(t, result)
+		mockClient.AssertExpectations(t)
 
 		// Tiger Style: Test that select-window failure returns false (fail-fast)
-		// ASSERTION: When select-window fails, return false immediately without trying select-pane
-		tmuxRunner = func(args ...string) (string, string, error) {
-			if args[0] == "list-panes" {
-				return "%1", "", nil
-			} else if args[0] == "select-window" {
-				return "", "invalid target", errors.New("invalid target")
-			}
-			return "", "", nil
-		}
-		result = JumpToPane("$999", "1", "%1")
-		if result {
-			t.Error("Expected false when select-window fails")
-		}
+		mockClient = new(tmux.MockClient)
+		mockClient.On("ValidatePaneExists", "$999", "1", "%1").Return(true, nil).Once()
+		mockClient.On("Run", []string{"select-window", "-t", "$999:1"}).Return("", "invalid target", tmux.ErrInvalidTarget).Once()
+		c = NewCore(mockClient)
+		result = c.JumpToPane("$999", "1", "%1")
+		require.False(t, result)
+		mockClient.AssertExpectations(t)
 
 		// Tiger Style: Test that select-pane failure returns false (error not swallowed)
-		// ASSERTION: When select-pane fails, return false and don't hide the error
-		selectPaneCalled = false
-		tmuxRunner = func(args ...string) (string, string, error) {
-			if args[0] == "list-panes" {
-				return "%1", "", nil // Pane exists
-			} else if args[0] == "select-window" {
-				return "", "", nil // Window exists
-			} else if args[0] == "select-pane" {
-				selectPaneCalled = true
-				return "", "invalid pane", errors.New("invalid pane")
-			}
-			return "", "", nil
-		}
-		result = JumpToPane("$0", "1", "%1")
-		if result {
-			t.Error("Expected false when select-pane fails (error not swallowed)")
-		}
-		if !selectPaneCalled {
-			t.Error("Expected select-pane to be called even though it will fail")
-		}
+		mockClient = new(tmux.MockClient)
+		mockClient.On("ValidatePaneExists", "$0", "1", "%1").Return(true, nil).Once()
+		mockClient.On("Run", []string{"select-window", "-t", "$0:1"}).Return("", "", nil).Once()
+		mockClient.On("Run", []string{"select-pane", "-t", "$0:1.%1"}).Return("", "invalid pane", tmux.ErrInvalidTarget).Once()
+		c = NewCore(mockClient)
+		result = c.JumpToPane("$0", "1", "%1")
+		require.False(t, result)
+		mockClient.AssertExpectations(t)
 
 		// Tiger Style: Test that empty parameters are rejected (input validation)
-		// ASSERTION: Empty session/window/pane should return false immediately
-		result = JumpToPane("", "1", "%1")
-		if result {
-			t.Error("Expected false when sessionID is empty")
-		}
+		mockClient = new(tmux.MockClient)
+		c = NewCore(mockClient)
+		result = c.JumpToPane("", "1", "%1")
+		require.False(t, result)
 
-		result = JumpToPane("$0", "", "%1")
-		if result {
-			t.Error("Expected false when windowID is empty")
-		}
+		result = c.JumpToPane("$0", "", "%1")
+		require.False(t, result)
 
-		result = JumpToPane("$0", "1", "")
-		if result {
-			t.Error("Expected false when paneID is empty")
-		}
-
-		// Tiger Style: Test pane reference format is correct (sessionID:paneID, not sessionID:windowID.paneID)
-		// ASSERTION: select-pane must be called with correct format (sessionID:paneID)
-		var capturedTarget string
-		tmuxRunner = func(args ...string) (string, string, error) {
-			if args[0] == "list-panes" {
-				return "%95", "", nil
-			} else if args[0] == "select-window" {
-				return "", "", nil
-			} else if args[0] == "select-pane" {
-				// Capture the target argument
-				for i, arg := range args {
-					if arg == "-t" && i+1 < len(args) {
-						capturedTarget = args[i+1]
-						break
-					}
-				}
-				return "", "", nil
-			}
-			return "", "", nil
-		}
-		JumpToPane("$2", "@6", "%95")
-		// The format should be sessionID:windowID.paneID
-		if capturedTarget != "$2:@6.%95" {
-			t.Errorf("Expected pane target format '$2:@6.%%95', got '%s'", capturedTarget)
-		}
+		result = c.JumpToPane("$0", "1", "")
+		require.False(t, result)
 	})
 
 	t.Run("GetTmuxVisibility", func(t *testing.T) {
 		// Test when variable is set to 1
-		tmuxRunner = func(args ...string) (string, string, error) {
-			return "TMUX_INTRAY_VISIBLE=1", "", nil
-		}
-		result := GetTmuxVisibility()
-		if result != "1" {
-			t.Errorf("Expected '1', got '%s'", result)
-		}
+		mockClient := new(tmux.MockClient)
+		mockClient.On("GetEnvironment", "TMUX_INTRAY_VISIBLE").Return("1", nil).Once()
+		c := NewCore(mockClient)
+		result := c.GetTmuxVisibility()
+		require.Equal(t, "1", result)
+		mockClient.AssertExpectations(t)
 
 		// Test when variable is set to 0
-		tmuxRunner = func(args ...string) (string, string, error) {
-			return "TMUX_INTRAY_VISIBLE=0", "", nil
-		}
-		result = GetTmuxVisibility()
-		if result != "0" {
-			t.Errorf("Expected '0', got '%s'", result)
-		}
+		mockClient = new(tmux.MockClient)
+		mockClient.On("GetEnvironment", "TMUX_INTRAY_VISIBLE").Return("0", nil).Once()
+		c = NewCore(mockClient)
+		result = c.GetTmuxVisibility()
+		require.Equal(t, "0", result)
+		mockClient.AssertExpectations(t)
 
 		// Test when variable is not set
-		tmuxRunner = func(args ...string) (string, string, error) {
-			return "", "", errors.New("variable not found")
-		}
-		result = GetTmuxVisibility()
-		if result != "0" {
-			t.Errorf("Expected '0' when variable is not set, got '%s'", result)
-		}
+		mockClient = new(tmux.MockClient)
+		mockClient.On("GetEnvironment", "TMUX_INTRAY_VISIBLE").Return("", tmux.ErrTmuxNotRunning).Once()
+		c = NewCore(mockClient)
+		result = c.GetTmuxVisibility()
+		require.Equal(t, "0", result)
+		mockClient.AssertExpectations(t)
 	})
 
 	t.Run("SetTmuxVisibility", func(t *testing.T) {
 		// Test successful set
-		tmuxRunner = func(args ...string) (string, string, error) {
-			return "", "", nil
-		}
-		result := SetTmuxVisibility("1")
-		if !result {
-			t.Error("Expected true when set succeeds")
-		}
+		mockClient := new(tmux.MockClient)
+		mockClient.On("SetEnvironment", "TMUX_INTRAY_VISIBLE", "1").Return(nil).Once()
+		c := NewCore(mockClient)
+		result := c.SetTmuxVisibility("1")
+		require.True(t, result)
+		mockClient.AssertExpectations(t)
 
 		// Test failed set
-		tmuxRunner = func(args ...string) (string, string, error) {
-			return "", "invalid option", errors.New("invalid option")
-		}
-		result = SetTmuxVisibility("1")
-		if result {
-			t.Error("Expected false when set fails")
-		}
+		mockClient = new(tmux.MockClient)
+		mockClient.On("SetEnvironment", "TMUX_INTRAY_VISIBLE", "1").Return(tmux.ErrTmuxNotRunning).Once()
+		c = NewCore(mockClient)
+		result = c.SetTmuxVisibility("1")
+		require.False(t, result)
+		mockClient.AssertExpectations(t)
 	})
 
 	t.Run("GetCurrentTmuxContext", func(t *testing.T) {
 		// Tiger Style: Test successful parsing of 4-part format
-		// ASSERTION: Format string produces 4 parts: session_id window_id pane_id pane_pid
-		tmuxRunner = func(args ...string) (string, string, error) {
-			// Return format: #{session_id} #{window_id} #{pane_id} #{pane_pid}
-			return "$3 @16 %21 8443\n", "", nil
-		}
-		ctx := GetCurrentTmuxContext()
-		if ctx.SessionID != "$3" {
-			t.Errorf("Expected SessionID '$3', got '%s'", ctx.SessionID)
-		}
-		if ctx.WindowID != "@16" {
-			t.Errorf("Expected WindowID '@16', got '%s'", ctx.WindowID)
-		}
-		if ctx.PaneID != "%21" {
-			t.Errorf("Expected PaneID '%%21', got '%s'", ctx.PaneID)
-		}
-		if ctx.PaneCreated != "8443" {
-			t.Errorf("Expected PaneCreated '8443', got '%s'", ctx.PaneCreated)
-		}
-
-		// Tiger Style: Test with extra whitespace (multiple spaces)
-		// ASSERTION: Extra spaces should be filtered out
-		tmuxRunner = func(args ...string) (string, string, error) {
-			return "$0  @5   %10    1234\n", "", nil
-		}
-		ctx = GetCurrentTmuxContext()
-		if ctx.SessionID != "$0" || ctx.WindowID != "@5" || ctx.PaneID != "%10" || ctx.PaneCreated != "1234" {
-			t.Error("Expected filtering of multiple spaces to work correctly")
-		}
-
-		// Tiger Style: Test format error (too few parts)
-		// ASSERTION: Should return empty context when format is wrong
-		tmuxRunner = func(args ...string) (string, string, error) {
-			return "$0 @5 %10\n", "", nil // Only 3 parts, should fail
-		}
-		ctx = GetCurrentTmuxContext()
-		if ctx.SessionID != "" {
-			t.Errorf("Expected empty SessionID for invalid format, got '%s'", ctx.SessionID)
-		}
-
-		// Tiger Style: Test format error (too many parts)
-		// ASSERTION: Should return empty context when format has extra parts
-		tmuxRunner = func(args ...string) (string, string, error) {
-			return "$0 @5 %10 1234 extra\n", "", nil // 5 parts, should fail
-		}
-		ctx = GetCurrentTmuxContext()
-		if ctx.SessionID != "" {
-			t.Errorf("Expected empty SessionID for invalid format, got '%s'", ctx.SessionID)
-		}
-
-		// Tiger Style: Test empty session_id (validation)
-		// ASSERTION: Should return empty context when session_id is empty
-		tmuxRunner = func(args ...string) (string, string, error) {
-			return " @5 %10 1234\n", "", nil // Empty session_id
-		}
-		ctx = GetCurrentTmuxContext()
-		if ctx.SessionID != "" {
-			t.Errorf("Expected empty SessionID when input has empty session_id, got '%s'", ctx.SessionID)
-		}
+		mockClient := new(tmux.MockClient)
+		mockClient.On("GetCurrentContext").Return(tmux.TmuxContext{
+			SessionID: "$3",
+			WindowID:  "@16",
+			PaneID:    "%21",
+			PanePID:   "8443",
+		}, nil).Once()
+		c := NewCore(mockClient)
+		ctx := c.GetCurrentTmuxContext()
+		require.Equal(t, "$3", ctx.SessionID)
+		require.Equal(t, "@16", ctx.WindowID)
+		require.Equal(t, "%21", ctx.PaneID)
+		require.Equal(t, "8443", ctx.PaneCreated)
+		mockClient.AssertExpectations(t)
 
 		// Tiger Style: Test tmux command failure
-		// ASSERTION: Should return empty context when tmux command fails
-		tmuxRunner = func(args ...string) (string, string, error) {
-			return "", "not in a tmux session", errors.New("command failed")
-		}
-		ctx = GetCurrentTmuxContext()
-		if ctx.SessionID != "" {
-			t.Errorf("Expected empty SessionID on command failure, got '%s'", ctx.SessionID)
-		}
+		mockClient = new(tmux.MockClient)
+		mockClient.On("GetCurrentContext").Return(tmux.TmuxContext{}, tmux.ErrTmuxNotRunning).Once()
+		c = NewCore(mockClient)
+		ctx = c.GetCurrentTmuxContext()
+		require.Equal(t, "", ctx.SessionID)
+		mockClient.AssertExpectations(t)
 	})
 }
 


### PR DESCRIPTION
Replace package-level tmuxRunner variable with dependency injection pattern using TmuxClient interface.

Changes:
- Add Core struct with injected TmuxClient
- Add NewCore() factory function for creating Core instances
- Convert all tmux functions to Core methods:
  - EnsureTmuxRunning()
  - GetCurrentTmuxContext()
  - ValidatePaneExists()
  - JumpToPane()
  - GetTmuxVisibility()
  - SetTmuxVisibility()
  - AddTrayItem()
- Add backward compatibility wrapper functions using defaultCore
- Update tests to use MockClient instead of mocking tmuxRunner
- Remove package-level tmuxRunner variable

Benefits:
- Testable code with proper mock support
- No mutable package-level state
- Cleaner separation of concerns
- Better error propagation
- Full backward compatibility maintained

Related Phase 2 tasks:
- tmux-intray-1hxt: ✅ Migrate GetCurrentTmuxContext
- tmux-intray-bax6: ✅ Migrate visibility functions
- tmux-intray-fgth: ✅ Migrate ValidatePaneExists/JumpToPane
- tmux-intray-ahty: ✅ Remove tmuxRunner variable
- tmux-intray-p9k3: ✅ Update tests to use MockClient

All Phase 2 core migration tasks are now complete.