### PR TITLE
refactor(tui): migrate to TmuxClient interface

### DIFF
--- a/cmd/tmux-intray/tui.go
+++ b/cmd/tmux-intray/tui.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cristianoliveira/tmux-intray/internal/colors"
 	"github.com/cristianoliveira/tmux-intray/internal/settings"
 	"github.com/cristianoliveira/tmux-intray/internal/storage"
+	"github.com/cristianoliveira/tmux-intray/internal/tmux"
 	"github.com/cristianoliveira/tmux-intray/internal/tui/state"
 	"github.com/spf13/cobra"
 )
@@ -45,6 +46,9 @@ func runTUI(cmd *cobra.Command, args []string) {
 	// Initialize storage
 	storage.Init()
 
+	// Create TmuxClient
+	client := tmux.NewDefaultClient()
+
 	// Load settings from disk (use defaults if missing/corrupted)
 	loadedSettings, err := settings.Load()
 	if err != nil {
@@ -54,7 +58,7 @@ func runTUI(cmd *cobra.Command, args []string) {
 	colors.Debug("Loaded settings for TUI")
 
 	// Create TUI model
-	model, err := state.NewModel()
+	model, err := state.NewModel(client)
 	if err != nil {
 		colors.Error(fmt.Sprintf("Failed to create TUI model: %v", err))
 		os.Exit(1)

--- a/internal/tui/state/model_integration_test.go
+++ b/internal/tui/state/model_integration_test.go
@@ -1,0 +1,61 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/cristianoliveira/tmux-intray/internal/storage"
+	"github.com/cristianoliveira/tmux-intray/internal/tmux"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTUIWithRealTmuxClient verifies TUI works with real TmuxClient.
+// This is an integration test that requires tmux to be running.
+func TestTUIWithRealTmuxClient(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	setupStorage(t)
+
+	// Create real TmuxClient
+	client := tmux.NewDefaultClient()
+
+	// Verify tmux is running
+	hasSession, err := client.HasSession()
+	if err != nil || !hasSession {
+		t.Skip("tmux not running, skipping integration test")
+	}
+
+	// Add a test notification
+	_, err = storage.AddNotification("Test notification for TUI", "", "$1", "@1", "%1", "", "info")
+	require.NoError(t, err)
+
+	// Create TUI model with real client
+	model, err := NewModel(client)
+	require.NoError(t, err)
+	require.NotNil(t, model)
+
+	// Verify session names were loaded
+	require.NotEmpty(t, model.sessionNames, "session names should be loaded from tmux")
+
+	// Verify notification was loaded
+	require.NotEmpty(t, model.notifications, "notifications should be loaded from storage")
+	require.NotEmpty(t, model.filtered, "filtered notifications should not be empty")
+
+	// Verify session name lookup works
+	sessionName := model.getSessionName("$1")
+	require.NotEmpty(t, sessionName, "session name should be found")
+}
+
+// TestTUIClientNilDefaults tests that NewModel creates a default client when nil is passed.
+func TestTUIClientNilDefaults(t *testing.T) {
+	setupStorage(t)
+
+	// Create TUI model with nil client (should create default)
+	model, err := NewModel(nil)
+	require.NoError(t, err)
+	require.NotNil(t, model)
+
+	// Verify client was created
+	require.NotNil(t, model.client, "default client should be created")
+}


### PR DESCRIPTION
- Update TUI model to accept TmuxClient dependency
- Remove direct tmux command execution in favor of TmuxClient
- Add integration tests for TUI with real TmuxClient
- Update unit tests to use MockClient
- Improve session name caching with initial fetch from TmuxClient