### PR TITLE
feat(tmux): add version logging and fix bin variable

### DIFF
--- a/tmux-intray.tmux
+++ b/tmux-intray.tmux
@@ -4,18 +4,21 @@
 # Get the plugin directory
 PLUGIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-TMUX_INTRAY_BIN=${TMUX_INTRAY_BIN:-"tmux-intray"}
+TMUX_INTRAY=${TMUX_INTRAY_BIN:-"tmux-intray"}
+
+echo "tmux-intray: Version $TMUX_INTRAY_BIN"
 
 # Set up tmux key bindings
 set_tmux_bindings() {
-    tmux bind-key -T prefix I run-shell "$TMUX_INTRAY_BIN follow"
-    tmux bind-key -T prefix J run-shell "tmux popup -E -h 50% -w 70% \"$TMUX_INTRAY_BIN tui\""
+    tmux bind-key -T prefix I run-shell "$TMUX_INTRAY follow"
+    tmux bind-key -T prefix J run-shell "tmux popup -E -h 50% -w 70% \"$TMUX_INTRAY tui\""
 }
 
 # Initialize the plugin
 initialize_intray() {
     tmux set-environment -g TMUX_INTRAY_VERSION "0.1.0"
     tmux set-environment -g TMUX_INTRAY_DIR "$PLUGIN_DIR"
+    tmux set-environment -g TMUX_INTRAY_BIN "$TMUX_INTRAY"
 }
 
 initialize_intray


### PR DESCRIPTION
This commit adds version logging to the tmux-intray plugin and fixes the variable name for the tmux-intray binary. Detailed Changes:
 - Implementation:
   - Changed the variable name from TMUX_INTRAY_BIN to TMUX_INTRAY for the binary command.
   - Added an echo command to log the plugin version on load.
   - Updated the tmux bindings to use the new TMUX_INTRAY variable.
   - Added setting the TMUX_INTRAY_BIN environment variable from the TMUX_INTRAY value.