### PR TITLE
tmux-intray-3ubr: Remove unused imports and add goimports pre-commit …

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ Detailed development guidelines in [DEVELOPMENT.md](./DEVELOPMENT.md).
 
 ### Go Code Style
 - **Package Structure**: cmd/ (CLI entry points), internal/ (private packages), tests/ (Bats integration tests), scripts/ (helpers). See [Go Package Structure](./docs/design/go-package-structure.md)
-- **Imports**: Group into stdlib, external, internal with blank lines. Sort alphabetically.
+- **Imports**: Group into stdlib, external, internal with blank lines. Sort alphabetically. Use `goimports` to automatically format imports and remove unused imports.
 - **Formatting**: Tabs for indentation (enforced by gofmt), aim for 100 char lines, no trailing whitespace, always final newline.
 - **Naming**: Packages `lowercase`, files `lowercase_with_underscores.go`, functions `PascalCase` (exported) / `camelCase` (private), constants `PascalCase` (exported) / `camelCase` (private), interfaces `PascalCase` ending in `er`, errors `Err` prefix.
 - **Types**: Use concrete types unless interface needed. Use `string` for TSV field values. Use exported constants for field indices. Use `error` return values; never panic on expected errors.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,9 +5,10 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/cristianoliveira/tmux-intray/internal/hooks"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 // RootCmd represents the base command when called without any subcommands

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -4,8 +4,6 @@ package hooks
 import (
 	"context"
 	"fmt"
-	"github.com/cristianoliveira/tmux-intray/internal/colors"
-	"github.com/cristianoliveira/tmux-intray/internal/config"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -14,6 +12,9 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/cristianoliveira/tmux-intray/internal/colors"
+	"github.com/cristianoliveira/tmux-intray/internal/config"
 )
 
 // File permission constants

--- a/scripts/go-pre-commit.sh
+++ b/scripts/go-pre-commit.sh
@@ -2,6 +2,16 @@
 
 set -euo pipefail
 
+# Run goimports on staged Go files
+echo "Running goimports..."
+goimports_output=$(goimports -l "$@")
+if [[ -n "$goimports_output" ]]; then
+    echo "The following files have import formatting issues:"
+    echo "$goimports_output"
+    echo "Please run 'goimports -w .'"
+    exit 1
+fi
+
 # Run gofmt on staged Go files
 echo "Running gofmt..."
 gofmt_output=$(gofmt -l "$@")


### PR DESCRIPTION
…hook

- Run goimports on all Go files, fixing import grouping
- Updated pre-commit hook to check goimports formatting
- Added goimports usage note to style guide in AGENTS.md
- No unused imports found; import ordering corrected