### PR TITLE
feat: add read_timestamp field and mark read/unread functionality

### DIFF
--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -9,17 +9,19 @@ import (
 	"github.com/cristianoliveira/tmux-intray/internal/storage"
 )
 
-// Field indices matching storage package
+// Field indices matching storage package.
 const (
-	fieldID          = 0
-	fieldTimestamp   = 1
-	fieldState       = 2
-	fieldSession     = 3
-	fieldWindow      = 4
-	fieldPane        = 5
-	fieldMessage     = 6
-	fieldPaneCreated = 7
-	fieldLevel       = 8
+	fieldID            = 0
+	fieldTimestamp     = 1
+	fieldState         = 2
+	fieldSession       = 3
+	fieldWindow        = 4
+	fieldPane          = 5
+	fieldMessage       = 6
+	fieldPaneCreated   = 7
+	fieldLevel         = 8
+	fieldReadTimestamp = 9
+	numFields          = 10
 )
 
 // GetTrayItems returns tray items for a given state filter.
@@ -39,6 +41,11 @@ func GetTrayItems(stateFilter string) (string, error) {
 			continue
 		}
 		fields := strings.Split(line, "\t")
+		if len(fields) < numFields {
+			for len(fields) < numFields {
+				fields = append(fields, "")
+			}
+		}
 		// Bounds check for fieldMessage
 		if len(fields) <= fieldMessage {
 			continue
@@ -90,6 +97,16 @@ func AddTrayItem(item, session, window, pane, paneCreated string, noAuto bool, l
 // ClearTrayItems dismisses all active tray items.
 func ClearTrayItems() error {
 	return storage.DismissAll()
+}
+
+// MarkNotificationRead marks a notification as read.
+func MarkNotificationRead(id string) error {
+	return storage.MarkNotificationRead(id)
+}
+
+// MarkNotificationUnread marks a notification as unread.
+func MarkNotificationUnread(id string) error {
+	return storage.MarkNotificationUnread(id)
 }
 
 // GetVisibility returns the visibility state as "0" or "1".

--- a/internal/notification/notification.go
+++ b/internal/notification/notification.go
@@ -7,22 +7,23 @@ import (
 
 // Notification represents a single notification record.
 type Notification struct {
-	ID          int
-	Timestamp   string
-	State       string
-	Session     string
-	Window      string
-	Pane        string
-	Message     string
-	PaneCreated string
-	Level       string
+	ID            int
+	Timestamp     string
+	State         string
+	Session       string
+	Window        string
+	Pane          string
+	Message       string
+	PaneCreated   string
+	Level         string
+	ReadTimestamp string
 }
 
 // ParseNotification parses a TSV line into a Notification.
 func ParseNotification(line string) (Notification, error) {
 	fields := strings.Split(line, "\t")
-	// Ensure at least 9 fields
-	for len(fields) < 9 {
+	// Ensure at least 10 fields
+	for len(fields) < 10 {
 		fields = append(fields, "")
 	}
 	id := 0
@@ -30,15 +31,16 @@ func ParseNotification(line string) (Notification, error) {
 		fmt.Sscanf(fields[0], "%d", &id)
 	}
 	return Notification{
-		ID:          id,
-		Timestamp:   fields[1],
-		State:       fields[2],
-		Session:     fields[3],
-		Window:      fields[4],
-		Pane:        fields[5],
-		Message:     unescapeMessage(fields[6]),
-		PaneCreated: fields[7],
-		Level:       fields[8],
+		ID:            id,
+		Timestamp:     fields[1],
+		State:         fields[2],
+		Session:       fields[3],
+		Window:        fields[4],
+		Pane:          fields[5],
+		Message:       unescapeMessage(fields[6]),
+		PaneCreated:   fields[7],
+		Level:         fields[8],
+		ReadTimestamp: fields[9],
 	}, nil
 }
 

--- a/internal/notification/notification_test.go
+++ b/internal/notification/notification_test.go
@@ -3,7 +3,7 @@ package notification
 import "testing"
 
 func TestParseNotification(t *testing.T) {
-	line := "1\t2025-01-01T12:00:00Z\tactive\tsess\twin\tpane\ttest\\tmessage\t123\tinfo"
+	line := "1\t2025-01-01T12:00:00Z\tactive\tsess\twin\tpane\ttest\\tmessage\t123\tinfo\t2025-01-02T01:02:03Z"
 	notif, err := ParseNotification(line)
 	if err != nil {
 		t.Fatal(err)
@@ -22,6 +22,9 @@ func TestParseNotification(t *testing.T) {
 	}
 	if notif.Level != "info" {
 		t.Errorf("Level mismatch")
+	}
+	if notif.ReadTimestamp != "2025-01-02T01:02:03Z" {
+		t.Errorf("ReadTimestamp mismatch")
 	}
 }
 

--- a/internal/storage/bounds_test.go
+++ b/internal/storage/bounds_test.go
@@ -31,10 +31,10 @@ func TestBoundsChecking(t *testing.T) {
 		"7\t2025-01-01T12:00:00Z\tactive\tsess1\twin1\tpane1\tmessage7\n" +
 		// Line 8: 8 fields (up to paneCreated)
 		"8\t2025-01-01T12:00:00Z\tactive\tsess1\twin1\tpane1\tmessage8\tcreated8\n" +
-		// Line 9: Complete 9 fields (valid)
+		// Line 9: Complete 9 fields (valid legacy)
 		"9\t2025-01-01T12:00:00Z\tactive\tsess1\twin1\tpane1\tmessage9\tcreated9\tinfo\n" +
-		// Line 10: Extra fields (10 fields - should be handled gracefully)
-		"10\t2025-01-01T12:00:00Z\tactive\tsess1\twin1\tpane1\tmessage10\tcreated10\tinfo\textra\n"
+		// Line 10: Extra fields (11 fields - should be handled gracefully)
+		"10\t2025-01-01T12:00:00Z\tactive\tsess1\twin1\tpane1\tmessage10\tcreated10\tinfo\textra\textra2\n"
 
 	err := os.WriteFile(notifFile, []byte(malformedData), 0644)
 	require.NoError(t, err)

--- a/internal/storage/notification_test.go
+++ b/internal/storage/notification_test.go
@@ -34,7 +34,7 @@ func TestGetNotificationByID(t *testing.T) {
 				require.NoError(t, err)
 			},
 			id:        "1",
-			wantLine:  "1\t2025-02-04T10:00:00Z\tactive\tsession1\twindow1\tpane1\ttest message\t123456\tinfo",
+			wantLine:  "1\t2025-02-04T10:00:00Z\tactive\tsession1\twindow1\tpane1\ttest message\t123456\tinfo\t",
 			wantError: false,
 		},
 		{
@@ -49,7 +49,7 @@ func TestGetNotificationByID(t *testing.T) {
 				DismissNotification("1")
 			},
 			id:        "1",
-			wantLine:  "1\t2025-02-04T10:00:00Z\tdismissed\tsession1\twindow1\tpane1\ttest message\t123456\tinfo",
+			wantLine:  "1\t2025-02-04T10:00:00Z\tdismissed\tsession1\twindow1\tpane1\ttest message\t123456\tinfo\t",
 			wantError: false,
 		},
 		{
@@ -92,7 +92,7 @@ func TestGetNotificationByID(t *testing.T) {
 				DismissNotification("1")
 			},
 			id:        "1",
-			wantLine:  "1\t2025-02-04T10:00:00Z\tdismissed\tsession1\twindow1\tpane1\ttest message\t123456\tinfo",
+			wantLine:  "1\t2025-02-04T10:00:00Z\tdismissed\tsession1\twindow1\tpane1\ttest message\t123456\tinfo\t",
 			wantError: false,
 		},
 	}
@@ -156,7 +156,7 @@ func TestGetNotificationByIDWithLock(t *testing.T) {
 		return
 	}
 
-	expected := "1\t2025-02-04T10:00:00Z\tactive\tsession1\twindow1\tpane1\ttest message\t123456\tinfo"
+	expected := "1\t2025-02-04T10:00:00Z\tactive\tsession1\twindow1\tpane1\ttest message\t123456\tinfo\t"
 	if line != expected {
 		t.Errorf("Got line %q, want %q", line, expected)
 	}

--- a/internal/tmuxintray/tmuxintray.go
+++ b/internal/tmuxintray/tmuxintray.go
@@ -12,18 +12,20 @@ import (
 	"github.com/cristianoliveira/tmux-intray/internal/storage"
 )
 
-// Field indices matching storage package
+// Field indices matching storage package.
+// TSV schema: id, timestamp, state, session, window, pane, message, pane_created, level, read_timestamp.
 const (
-	fieldID          = 0
-	fieldTimestamp   = 1
-	fieldState       = 2
-	fieldSession     = 3
-	fieldWindow      = 4
-	fieldPane        = 5
-	fieldMessage     = 6
-	fieldPaneCreated = 7
-	fieldLevel       = 8
-	numFields        = 9
+	fieldID            = 0
+	fieldTimestamp     = 1
+	fieldState         = 2
+	fieldSession       = 3
+	fieldWindow        = 4
+	fieldPane          = 5
+	fieldMessage       = 6
+	fieldPaneCreated   = 7
+	fieldLevel         = 8
+	fieldReadTimestamp = 9
+	numFields          = 10
 )
 
 // Init initializes all internal packages in the correct order.
@@ -80,6 +82,16 @@ func DismissAllNotifications() error {
 	return storage.DismissAll()
 }
 
+// MarkNotificationRead marks a notification as read.
+func MarkNotificationRead(id string) error {
+	return storage.MarkNotificationRead(id)
+}
+
+// MarkNotificationUnread marks a notification as unread.
+func MarkNotificationUnread(id string) error {
+	return storage.MarkNotificationUnread(id)
+}
+
 // CleanupOldNotifications removes dismissed notifications older than the given days.
 // If dryRun is true, only logs what would be removed.
 func CleanupOldNotifications(days int, dryRun bool) {
@@ -107,15 +119,16 @@ func SetVisibility(visible bool) error {
 
 // Notification represents a single notification in the tray.
 type Notification struct {
-	ID          string
-	Timestamp   string
-	State       string
-	Session     string
-	Window      string
-	Pane        string
-	Message     string
-	PaneCreated string
-	Level       string
+	ID            string
+	Timestamp     string
+	State         string
+	Session       string
+	Window        string
+	Pane          string
+	Message       string
+	PaneCreated   string
+	Level         string
+	ReadTimestamp string
 }
 
 // unescapeMessage reverses the escaping applied by storage package.
@@ -139,14 +152,15 @@ func ParseNotification(tsvLine string) (Notification, error) {
 		}
 	}
 	return Notification{
-		ID:          fields[fieldID],
-		Timestamp:   fields[fieldTimestamp],
-		State:       fields[fieldState],
-		Session:     fields[fieldSession],
-		Window:      fields[fieldWindow],
-		Pane:        fields[fieldPane],
-		Message:     unescapeMessage(fields[fieldMessage]),
-		PaneCreated: fields[fieldPaneCreated],
-		Level:       fields[fieldLevel],
+		ID:            fields[fieldID],
+		Timestamp:     fields[fieldTimestamp],
+		State:         fields[fieldState],
+		Session:       fields[fieldSession],
+		Window:        fields[fieldWindow],
+		Pane:          fields[fieldPane],
+		Message:       unescapeMessage(fields[fieldMessage]),
+		PaneCreated:   fields[fieldPaneCreated],
+		Level:         fields[fieldLevel],
+		ReadTimestamp: fields[fieldReadTimestamp],
 	}, nil
 }


### PR DESCRIPTION
This commit adds a read_timestamp field to the notification TSV schema and implements MarkNotificationRead/MarkNotificationUnread functions to track notification read state.

Changes:
- Added read_timestamp field (field index 9) to notification schema
- Updated field constants to accommodate the new field (numFields = 10)
- Added MarkNotificationRead and MarkNotificationUnread functions to core, storage, and tmuxintray packages
- Updated ParseNotification to handle the new field
- Added normalizeFields helper for backward compatibility with legacy records
- Updated all test cases to expect the new field format