### PR TITLE
test: add mock client assertion to core and tmux tests

### DIFF
--- a/internal/core/core_test.go
+++ b/internal/core/core_test.go
@@ -81,6 +81,7 @@ func TestCore(t *testing.T) {
 		require.NotEmpty(t, id)
 		items, _ := GetTrayItems("active")
 		require.Contains(t, items, "manual message")
+		mockClient.AssertExpectations(t)
 	})
 
 	t.Run("ClearTrayItems", func(t *testing.T) {

--- a/internal/core/tmux_test.go
+++ b/internal/core/tmux_test.go
@@ -121,6 +121,7 @@ func TestTmuxFunctions(t *testing.T) {
 
 		result = c.JumpToPane("$0", "1", "")
 		require.False(t, result)
+		mockClient.AssertExpectations(t)
 	})
 
 	t.Run("GetTmuxVisibility", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- add mock client assertions in core and tmux test coverage
- keep behavior aligned with existing test patterns