### PR TITLE
fix(tui): grouped view bugs - empty display and lost expansion state

### DIFF
--- a/internal/tui/state/model.go
+++ b/internal/tui/state/model.go
@@ -1090,6 +1090,10 @@ func (m *Model) buildFilteredTree(notifications []notification.Notification) *No
 	// Prune empty groups (groups with no matching notifications)
 	m.pruneEmptyGroups(root)
 
+	// FIX: Set treeRoot before applying expansion state
+	// to ensure consistent key generation
+	m.treeRoot = root
+
 	// Apply saved expansion state where possible
 	if m.expansionState != nil {
 		m.applyExpansionState(root)


### PR DESCRIPTION
## Summary
Fixed two critical bugs in the TUI grouped view:

1. **Grouped View Empty**: When using `viewMode: "grouped"`, the TUI was empty even though entries existed in the database.
2. **Expansion State Lost**: When performing actions (dismiss, mark read/unread), the tree collapsed and all groups became folded again.

## Problem 1: Grouped View Empty
**Issue**: Users with `viewMode: "grouped"` in their config would see an empty TUI despite having tray items.

**Root Cause**: Initialization order bug - `applySearchFilter()` was called before `viewMode` was set, leaving `visibleNodes = nil`.

**Fix**: Added `applySearchFilter()` call at the end of `FromState()` method to rebuild tree with correct viewMode. This ensures the grouped tree is properly constructed after loading user state.

## Problem 2: Expansion State Lost
**Issue**: After any action (dismiss, mark read/unread), the tree would collapse, losing user's expansion state.

**Root Cause**: Key mismatch - `applyExpansionState()` depended on `m.treeRoot` for key generation, but `m.treeRoot` was nil during tree rebuild.

**Fix**: Set `m.treeRoot = root` before calling `applyExpansionState()` to ensure consistent key generation and preserve expansion state across actions.

## Testing/Validation
- Both fixes include comprehensive unit tests verifying the behavior.
- Manual testing with grouped view shows items appear correctly.
- Expansion state persists after dismiss/read/unread actions.

## Commits
- `9544e5a` fix(tui): rebuild grouping tree after loading user state (#83)
- `ec6436c` fix(tui): preserve expansion state after actions