### PR TITLE
Make grouped view the default in TUI settings

### DIFF
--- a/cmd/tmux-intray/settings_test.go
+++ b/cmd/tmux-intray/settings_test.go
@@ -122,7 +122,7 @@ func TestSettingsDefaults(t *testing.T) {
 	require.Equal(t, "desc", defaults.SortOrder)
 
 	// Verify default view mode
-	require.Equal(t, "compact", defaults.ViewMode)
+	require.Equal(t, settings.ViewModeGrouped, defaults.ViewMode)
 
 	// Verify default grouping settings
 	require.Equal(t, settings.GroupByNone, defaults.GroupBy)

--- a/docs/cli/CLI_REFERENCE.md
+++ b/docs/cli/CLI_REFERENCE.md
@@ -392,7 +392,7 @@ EXAMPLES:
         "window": "",
         "pane": ""
       },
-      "viewMode": "compact",
+      "viewMode": "grouped",
       "groupBy": "none",
       "defaultExpandLevel": 1,
       "expansionState": {}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -138,7 +138,7 @@ The settings file uses the following JSON schema:
     "window": "",
     "pane": ""
   },
-  "viewMode": "compact",
+  "viewMode": "grouped",
   "groupBy": "none",
   "defaultExpandLevel": 1,
   "expansionState": {}
@@ -157,7 +157,7 @@ The settings file uses the following JSON schema:
 | `filters.session` | string | Filter by tmux session | `""` (no filter) | Session name or `""` |
 | `filters.window` | string | Filter by tmux window | `""` (no filter) | Window ID or `""` |
 | `filters.pane` | string | Filter by tmux pane | `""` (no filter) | Pane ID or `""` |
-| `viewMode` | string | Display layout | `"compact"` | `"compact"`, `"detailed"` |
+| `viewMode` | string | Display layout | `"grouped"` | `"compact"`, `"detailed"`, `"grouped"` |
 | `groupBy` | string | Group notifications in the TUI | `"none"` | `"none"`, `"session"`, `"window"`, `"pane"` |
 | `defaultExpandLevel` | number | Default grouping expansion depth | `1` | `0`-`3` |
 | `expansionState` | object | Explicit expansion overrides by node path | `{}` | Object of string to boolean |
@@ -178,7 +178,7 @@ If the settings file doesn't exist or is corrupted, the TUI uses these defaults:
     "window": "",
     "pane": ""
   },
-  "viewMode": "compact",
+  "viewMode": "grouped",
   "groupBy": "none",
   "defaultExpandLevel": 1,
   "expansionState": {}

--- a/internal/settings/README.md
+++ b/internal/settings/README.md
@@ -20,7 +20,7 @@ Settings are persisted to `~/.config/tmux-intray/settings.json` as JSON:
     "window": "",
     "pane": ""
   },
-  "viewMode": "compact"
+  "viewMode": "grouped"
 }
 ```
 
@@ -83,6 +83,7 @@ Returns a Settings struct with all default values populated.
 ### View Mode
 - `ViewModeCompact` = "compact"
 - `ViewModeDetailed` = "detailed"
+- `ViewModeGrouped` = "grouped"
 
 ### Filter Levels
 - `LevelFilterInfo` = "info"

--- a/internal/settings/manager_test.go
+++ b/internal/settings/manager_test.go
@@ -26,7 +26,7 @@ func TestFromSettings(t *testing.T) {
 				SortBy:                SortByTimestamp,
 				SortOrder:             SortOrderDesc,
 				Filters:               Filter{},
-				ViewMode:              ViewModeCompact,
+				ViewMode:              ViewModeGrouped,
 				GroupBy:               GroupByNone,
 				DefaultExpandLevel:    1,
 				DefaultExpandLevelSet: true,

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -143,7 +143,7 @@ type Filter struct {
 //	    "window": "",
 //	    "pane": ""
 //	  },
-//	  "viewMode": "compact",
+//	  "viewMode": "grouped",
 //	  "groupBy": "none",
 //	  "defaultExpandLevel": 1,
 //	  "expansionState": {}
@@ -171,7 +171,7 @@ type Settings struct {
 	Filters Filter `json:"filters"`
 
 	// ViewMode specifies the display layout: "compact", "detailed", or "grouped".
-	// Empty string means use default view mode (compact).
+	// Empty string means use default view mode (grouped).
 	ViewMode string `json:"viewMode"`
 
 	// GroupBy specifies the grouping mode: "none", "session", "window", or "pane".
@@ -199,7 +199,7 @@ func DefaultSettings() *Settings {
 			Window:  "",
 			Pane:    "",
 		},
-		ViewMode:           ViewModeCompact,
+		ViewMode:           ViewModeGrouped,
 		GroupBy:            GroupByNone,
 		DefaultExpandLevel: 1,
 		ExpansionState:     map[string]bool{},

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -29,7 +29,7 @@ func TestDefaultSettings(t *testing.T) {
 	assert.Equal(t, "", s.Filters.Pane)
 
 	// Check view mode
-	assert.Equal(t, ViewModeCompact, s.ViewMode)
+	assert.Equal(t, ViewModeGrouped, s.ViewMode)
 
 	// Check grouping settings
 	assert.Equal(t, GroupByNone, s.GroupBy)
@@ -615,7 +615,7 @@ func TestReset(t *testing.T) {
 	assert.Equal(t, DefaultColumns, defaults.Columns)
 	assert.Equal(t, SortByTimestamp, defaults.SortBy)
 	assert.Equal(t, SortOrderDesc, defaults.SortOrder)
-	assert.Equal(t, ViewModeCompact, defaults.ViewMode)
+	assert.Equal(t, ViewModeGrouped, defaults.ViewMode)
 	assert.Equal(t, GroupByNone, defaults.GroupBy)
 	assert.Equal(t, 1, defaults.DefaultExpandLevel)
 }
@@ -634,7 +634,7 @@ func TestResetWhenFileDoesNotExist(t *testing.T) {
 	assert.Equal(t, DefaultColumns, defaults.Columns)
 	assert.Equal(t, SortByTimestamp, defaults.SortBy)
 	assert.Equal(t, SortOrderDesc, defaults.SortOrder)
-	assert.Equal(t, ViewModeCompact, defaults.ViewMode)
+	assert.Equal(t, ViewModeGrouped, defaults.ViewMode)
 	assert.Equal(t, GroupByNone, defaults.GroupBy)
 	assert.Equal(t, 1, defaults.DefaultExpandLevel)
 }


### PR DESCRIPTION
## Summary
- change `DefaultSettings()` to use grouped mode as the default view mode for new installations
- keep backward compatibility by preserving existing saved user settings
- update tests and docs that referenced compact as the default view mode

## Validation
- make tests
- make lint
- make check-fmt
- make security-check
- make go-build