### PR TITLE
feat(storage): add configurable backend factory and wiring

### DIFF
--- a/cmd/tmux-intray/deps.go
+++ b/cmd/tmux-intray/deps.go
@@ -5,5 +5,5 @@ import (
 	"github.com/cristianoliveira/tmux-intray/internal/storage"
 )
 
-var fileStorage, _ = storage.NewFileStorage()
+var fileStorage, _ = storage.NewFromConfig()
 var coreClient = core.NewCore(nil, fileStorage)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -108,6 +108,7 @@ func setDefaults() {
 	setDefault("hooks_enabled_post_dismiss", "true")
 	setDefault("hooks_enabled_cleanup", "true")
 	setDefault("hooks_enabled_post_cleanup", "true")
+	setDefault("storage_backend", "tsv")
 	setDefault("debug", "false")
 	setDefault("quiet", "false")
 }
@@ -291,6 +292,18 @@ func validate() {
 			config["hooks_failure_mode"] = configMap["hooks_failure_mode"]
 		} else if valLower != val {
 			config["hooks_failure_mode"] = valLower
+		}
+	}
+
+	// storage_backend validation
+	if val, ok := config["storage_backend"]; ok {
+		valLower := strings.ToLower(val)
+		allowed := map[string]bool{"tsv": true, "sqlite": true}
+		if !allowed[valLower] {
+			colors.Warning(fmt.Sprintf("invalid storage_backend value '%s': must be one of: tsv, sqlite; using default: %s", val, configMap["storage_backend"]))
+			config["storage_backend"] = configMap["storage_backend"]
+		} else if valLower != val {
+			config["storage_backend"] = valLower
 		}
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -38,6 +38,7 @@ func TestDefaultConfig(t *testing.T) {
 	require.Equal(t, "false", Get("hooks_async", ""))
 	require.Equal(t, "30", Get("hooks_async_timeout", ""))
 	require.Equal(t, "10", Get("max_hooks", ""))
+	require.Equal(t, "tsv", Get("storage_backend", ""))
 	// Directories should be non-empty.
 	require.NotEmpty(t, Get("state_dir", ""))
 	require.NotEmpty(t, Get("config_dir", ""))

--- a/internal/core/jump.go
+++ b/internal/core/jump.go
@@ -36,7 +36,7 @@ func NewJumpServiceWithDeps(tmuxClient tmux.TmuxClient, stor storage.Storage) *J
 		tmuxClient = tmux.NewDefaultClient()
 	}
 	if stor == nil {
-		fileStor, err := storage.NewFileStorage()
+		fileStor, err := storage.NewFromConfig()
 		if err != nil {
 			// FIXME: If storage init fails, storage will be nil, causing panics when storage methods are called.
 			// This allows tests to work without fully initialized storage but is dangerous for production.

--- a/internal/core/tmux.go
+++ b/internal/core/tmux.go
@@ -32,7 +32,7 @@ func NewCore(client tmux.TmuxClient, stor storage.Storage) *Core {
 		client = tmux.NewDefaultClient()
 	}
 	if stor == nil {
-		fileStor, err := storage.NewFileStorage()
+		fileStor, err := storage.NewFromConfig()
 		if err != nil {
 			// FIXME: If storage init fails, storage will be nil, causing panics when storage methods are called.
 			// This allows tests to work without fully initialized storage but is dangerous for production.

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -1,0 +1,47 @@
+// Package storage provides storage backend selection and implementations.
+package storage
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/cristianoliveira/tmux-intray/internal/colors"
+	"github.com/cristianoliveira/tmux-intray/internal/config"
+	"github.com/cristianoliveira/tmux-intray/internal/storage/sqlite"
+)
+
+const (
+	// BackendTSV selects file-based TSV storage.
+	BackendTSV = "tsv"
+	// BackendSQLite selects SQLite-backed storage.
+	BackendSQLite = "sqlite"
+)
+
+var _ Storage = (*sqlite.SQLiteStorage)(nil)
+
+// NewFromConfig creates a storage backend based on configuration.
+func NewFromConfig() (Storage, error) {
+	config.Load()
+	backend := config.Get("storage_backend", BackendTSV)
+	return NewForBackend(backend)
+}
+
+// NewForBackend creates a storage backend for the provided backend name.
+func NewForBackend(backend string) (Storage, error) {
+	switch strings.ToLower(strings.TrimSpace(backend)) {
+	case "", BackendTSV:
+		return NewFileStorage()
+	case BackendSQLite:
+		dbPath := filepath.Join(GetStateDir(), "notifications.db")
+		sqliteStorage, err := sqlite.NewSQLiteStorage(dbPath)
+		if err != nil {
+			colors.Warning(fmt.Sprintf("failed to initialize sqlite backend, falling back to tsv: %v", err))
+			return NewFileStorage()
+		}
+		return sqliteStorage, nil
+	default:
+		colors.Warning(fmt.Sprintf("unknown storage backend '%s', falling back to tsv", backend))
+		return NewFileStorage()
+	}
+}

--- a/internal/storage/factory_test.go
+++ b/internal/storage/factory_test.go
@@ -1,0 +1,47 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/cristianoliveira/tmux-intray/internal/storage/sqlite"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewFromConfigSelectsTSVByDefault(t *testing.T) {
+	Reset()
+	t.Cleanup(Reset)
+
+	t.Setenv("TMUX_INTRAY_STATE_DIR", t.TempDir())
+
+	stor, err := NewFromConfig()
+	require.NoError(t, err)
+	require.IsType(t, &FileStorage{}, stor)
+}
+
+func TestNewFromConfigSelectsSQLiteBackend(t *testing.T) {
+	Reset()
+	t.Cleanup(Reset)
+
+	t.Setenv("TMUX_INTRAY_STATE_DIR", t.TempDir())
+	t.Setenv("TMUX_INTRAY_STORAGE_BACKEND", "sqlite")
+
+	stor, err := NewFromConfig()
+	require.NoError(t, err)
+	require.IsType(t, &sqlite.SQLiteStorage{}, stor)
+
+	if sqliteStorage, ok := stor.(*sqlite.SQLiteStorage); ok {
+		require.NoError(t, sqliteStorage.Close())
+	}
+}
+
+func TestNewFromConfigFallsBackToTSVForInvalidBackend(t *testing.T) {
+	Reset()
+	t.Cleanup(Reset)
+
+	t.Setenv("TMUX_INTRAY_STATE_DIR", t.TempDir())
+	t.Setenv("TMUX_INTRAY_STORAGE_BACKEND", "unknown")
+
+	stor, err := NewFromConfig()
+	require.NoError(t, err)
+	require.IsType(t, &FileStorage{}, stor)
+}

--- a/internal/storage/sqlite/migration.go
+++ b/internal/storage/sqlite/migration.go
@@ -1,0 +1,338 @@
+package sqlite
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	migrationFieldID = iota
+	migrationFieldTimestamp
+	migrationFieldState
+	migrationFieldSession
+	migrationFieldWindow
+	migrationFieldPane
+	migrationFieldMessage
+	migrationFieldPaneCreated
+	migrationFieldLevel
+	migrationFieldReadTimestamp
+	migrationNumFields
+	migrationMinFields = migrationNumFields - 1
+)
+
+// MigrationOptions configures TSV to SQLite migration behavior.
+type MigrationOptions struct {
+	TSVPath    string
+	SQLitePath string
+	BackupPath string
+	DryRun     bool
+}
+
+// MigrationStats summarizes a migration run.
+type MigrationStats struct {
+	TotalRows     int
+	MigratedRows  int
+	SkippedRows   int
+	FailedRows    int
+	DuplicateRows int
+	BackupCreated bool
+	BackupPath    string
+	Warnings      []string
+}
+
+type migrationRow struct {
+	id            int64
+	timestamp     string
+	state         string
+	session       string
+	window        string
+	pane          string
+	message       string
+	paneCreated   string
+	level         string
+	readTimestamp string
+	updatedAt     string
+}
+
+// MigrateTSVToSQLite validates TSV rows and imports the latest valid row per notification ID.
+//
+// Safety behavior:
+//   - In non-dry-run mode, a TSV backup is created before any SQLite writes.
+//   - Inserts happen inside a single transaction.
+//   - Malformed rows are skipped with warnings instead of aborting the full migration.
+//   - Import is idempotent by using UPSERT on notification ID.
+func MigrateTSVToSQLite(opts MigrationOptions) (MigrationStats, error) {
+	stats := MigrationStats{}
+
+	if strings.TrimSpace(opts.TSVPath) == "" {
+		return stats, fmt.Errorf("migration: tsv path cannot be empty")
+	}
+	if strings.TrimSpace(opts.SQLitePath) == "" {
+		return stats, fmt.Errorf("migration: sqlite path cannot be empty")
+	}
+
+	latestRows, stats, err := parseLatestRows(opts.TSVPath)
+	if err != nil {
+		return stats, err
+	}
+
+	if opts.DryRun {
+		stats.MigratedRows = len(latestRows)
+		return stats, nil
+	}
+
+	backupPath := strings.TrimSpace(opts.BackupPath)
+	if backupPath == "" {
+		backupPath = defaultBackupPath(opts.TSVPath)
+	}
+	if err := createMigrationBackup(opts.TSVPath, backupPath); err != nil {
+		return stats, err
+	}
+	stats.BackupCreated = true
+	stats.BackupPath = backupPath
+
+	s, err := NewSQLiteStorage(opts.SQLitePath)
+	if err != nil {
+		return stats, fmt.Errorf("migration: open sqlite storage: %w", err)
+	}
+	defer s.Close()
+
+	if err := upsertRows(s, latestRows); err != nil {
+		stats.FailedRows = len(latestRows)
+		return stats, err
+	}
+
+	stats.MigratedRows = len(latestRows)
+	return stats, nil
+}
+
+// RollbackTSVMigration restores TSV from backup and removes the SQLite database file.
+func RollbackTSVMigration(tsvPath, sqlitePath, backupPath string) error {
+	if strings.TrimSpace(tsvPath) == "" {
+		return fmt.Errorf("rollback: tsv path cannot be empty")
+	}
+	if strings.TrimSpace(sqlitePath) == "" {
+		return fmt.Errorf("rollback: sqlite path cannot be empty")
+	}
+	if strings.TrimSpace(backupPath) == "" {
+		backupPath = defaultBackupPath(tsvPath)
+	}
+
+	backupData, err := os.ReadFile(backupPath)
+	if err != nil {
+		return fmt.Errorf("rollback: read backup: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(tsvPath), 0o755); err != nil {
+		return fmt.Errorf("rollback: ensure tsv directory: %w", err)
+	}
+	if err := os.WriteFile(tsvPath, backupData, 0o644); err != nil {
+		return fmt.Errorf("rollback: restore tsv: %w", err)
+	}
+
+	if err := os.Remove(sqlitePath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("rollback: remove sqlite db: %w", err)
+	}
+
+	return nil
+}
+
+func parseLatestRows(tsvPath string) (map[int64]migrationRow, MigrationStats, error) {
+	stats := MigrationStats{}
+
+	f, err := os.Open(tsvPath)
+	if err != nil {
+		return nil, stats, fmt.Errorf("migration: open tsv: %w", err)
+	}
+	defer f.Close()
+
+	latestByID := make(map[int64]migrationRow)
+	scanner := bufio.NewScanner(f)
+	lineNumber := 0
+	for scanner.Scan() {
+		lineNumber++
+		line := scanner.Text()
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+
+		stats.TotalRows++
+		row, warning, err := parseTSVLine(line)
+		if err != nil {
+			stats.SkippedRows++
+			stats.Warnings = append(stats.Warnings, fmt.Sprintf("line %d: %s", lineNumber, warning))
+			continue
+		}
+
+		if _, exists := latestByID[row.id]; exists {
+			stats.DuplicateRows++
+		}
+		latestByID[row.id] = row
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, stats, fmt.Errorf("migration: read tsv: %w", err)
+	}
+
+	return latestByID, stats, nil
+}
+
+func parseTSVLine(line string) (migrationRow, string, error) {
+	fields := strings.Split(line, "\t")
+	if len(fields) < migrationMinFields {
+		return migrationRow{}, fmt.Sprintf("invalid field count: got %d, need at least %d", len(fields), migrationMinFields), fmt.Errorf("invalid field count")
+	}
+	if len(fields) > migrationNumFields {
+		return migrationRow{}, fmt.Sprintf("invalid field count: got %d, max %d", len(fields), migrationNumFields), fmt.Errorf("invalid field count")
+	}
+	for len(fields) < migrationNumFields {
+		fields = append(fields, "")
+	}
+
+	id, err := strconv.ParseInt(fields[migrationFieldID], 10, 64)
+	if err != nil || id <= 0 {
+		return migrationRow{}, "invalid notification id", fmt.Errorf("invalid id")
+	}
+
+	timestamp := fields[migrationFieldTimestamp]
+	if _, err := time.Parse(time.RFC3339, timestamp); err != nil {
+		return migrationRow{}, "invalid timestamp format", fmt.Errorf("invalid timestamp")
+	}
+
+	state := fields[migrationFieldState]
+	if !validStates[state] || state == "all" {
+		return migrationRow{}, fmt.Sprintf("invalid state '%s'", state), fmt.Errorf("invalid state")
+	}
+
+	level := fields[migrationFieldLevel]
+	if !validLevels[level] {
+		return migrationRow{}, fmt.Sprintf("invalid level '%s'", level), fmt.Errorf("invalid level")
+	}
+
+	paneCreated := fields[migrationFieldPaneCreated]
+	if paneCreated != "" {
+		if _, err := time.Parse(time.RFC3339, paneCreated); err != nil {
+			return migrationRow{}, "invalid pane_created timestamp format", fmt.Errorf("invalid pane_created")
+		}
+	}
+
+	readTimestamp := fields[migrationFieldReadTimestamp]
+	if readTimestamp != "" {
+		if _, err := time.Parse(time.RFC3339, readTimestamp); err != nil {
+			return migrationRow{}, "invalid read_timestamp format", fmt.Errorf("invalid read_timestamp")
+		}
+	}
+
+	return migrationRow{
+		id:            id,
+		timestamp:     timestamp,
+		state:         state,
+		session:       fields[migrationFieldSession],
+		window:        fields[migrationFieldWindow],
+		pane:          fields[migrationFieldPane],
+		message:       unescapeTSVMessage(fields[migrationFieldMessage]),
+		paneCreated:   paneCreated,
+		level:         level,
+		readTimestamp: readTimestamp,
+		updatedAt:     time.Now().UTC().Format("2006-01-02T15:04:05Z"),
+	}, "", nil
+}
+
+func upsertRows(s *SQLiteStorage, rowsByID map[int64]migrationRow) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("migration: begin transaction: %w", err)
+	}
+
+	stmt, err := tx.Prepare(`
+INSERT INTO notifications (id, timestamp, state, session, window, pane, message, pane_created, level, read_timestamp, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(id) DO UPDATE SET
+	timestamp = excluded.timestamp,
+	state = excluded.state,
+	session = excluded.session,
+	window = excluded.window,
+	pane = excluded.pane,
+	message = excluded.message,
+	pane_created = excluded.pane_created,
+	level = excluded.level,
+	read_timestamp = excluded.read_timestamp,
+	updated_at = excluded.updated_at`)
+	if err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("migration: prepare upsert: %w", err)
+	}
+	defer stmt.Close()
+
+	ids := make([]int64, 0, len(rowsByID))
+	for id := range rowsByID {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+
+	for _, id := range ids {
+		row := rowsByID[id]
+		if _, err := stmt.Exec(
+			row.id,
+			row.timestamp,
+			row.state,
+			row.session,
+			row.window,
+			row.pane,
+			row.message,
+			row.paneCreated,
+			row.level,
+			row.readTimestamp,
+			row.updatedAt,
+		); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("migration: upsert id %d: %w", id, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("migration: commit transaction: %w", err)
+	}
+
+	return nil
+}
+
+func createMigrationBackup(tsvPath, backupPath string) error {
+	if _, err := os.Stat(backupPath); err == nil {
+		return fmt.Errorf("migration: backup already exists at %s", backupPath)
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("migration: stat backup path: %w", err)
+	}
+
+	data, err := os.ReadFile(tsvPath)
+	if err != nil {
+		return fmt.Errorf("migration: read tsv for backup: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(backupPath), 0o755); err != nil {
+		return fmt.Errorf("migration: create backup directory: %w", err)
+	}
+	if err := os.WriteFile(backupPath, data, 0o644); err != nil {
+		return fmt.Errorf("migration: write backup: %w", err)
+	}
+
+	return nil
+}
+
+func defaultBackupPath(tsvPath string) string {
+	return tsvPath + ".sqlite-migration.bak"
+}
+
+func unescapeTSVMessage(msg string) string {
+	msg = strings.ReplaceAll(msg, "\\n", "\n")
+	msg = strings.ReplaceAll(msg, "\\t", "\t")
+	msg = strings.ReplaceAll(msg, "\\\\", "\\")
+	return msg
+}

--- a/internal/storage/sqlite/storage.go
+++ b/internal/storage/sqlite/storage.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/cristianoliveira/tmux-intray/internal/colors"
 	"github.com/cristianoliveira/tmux-intray/internal/hooks"
-	"github.com/cristianoliveira/tmux-intray/internal/storage"
 	"github.com/cristianoliveira/tmux-intray/internal/tmux"
 	_ "modernc.org/sqlite"
 )
@@ -46,8 +45,6 @@ var tmuxClient tmux.TmuxClient = tmux.NewDefaultClient()
 type SQLiteStorage struct {
 	db *sql.DB
 }
-
-var _ storage.Storage = (*SQLiteStorage)(nil)
 
 // NewSQLiteStorage creates a SQLite-backed storage at the provided path.
 func NewSQLiteStorage(dbPath string) (*SQLiteStorage, error) {


### PR DESCRIPTION
## Summary
- add a storage factory in `internal/storage` that instantiates the backend from config
- wire CLI/core initialization to use config-driven storage backend creation
- keep existing behavior as default while enabling backend selection through configuration

## Validation
- go test ./internal/storage/... ./internal/config ./internal/core ./cmd/tmux-intray