### PR TITLE
feat(search): add transparent name-based search for tmux sessions, wi…

### DIFF
--- a/internal/search/provider.go
+++ b/internal/search/provider.go
@@ -20,8 +20,11 @@ type Provider interface {
 
 // Options holds configuration options for creating search providers.
 type Options struct {
-	CaseInsensitive bool     // If true, searches ignore case sensitivity
-	Fields          []string // Fields to search in (default: all fields)
+	CaseInsensitive bool              // If true, searches ignore case sensitivity
+	Fields          []string          // Fields to search in (default: all fields)
+	SessionNames    map[string]string // Map of session ID to session name for name resolution
+	WindowNames     map[string]string // Map of window ID to window name for name resolution
+	PaneNames       map[string]string // Map of pane ID to pane name for name resolution
 }
 
 // DefaultOptions returns the default search options.
@@ -47,6 +50,27 @@ func WithCaseInsensitive(enabled bool) Option {
 func WithFields(fields []string) Option {
 	return func(o *Options) {
 		o.Fields = fields
+	}
+}
+
+// WithSessionNames sets the session ID to name mapping for name resolution.
+func WithSessionNames(names map[string]string) Option {
+	return func(o *Options) {
+		o.SessionNames = names
+	}
+}
+
+// WithWindowNames sets the window ID to name mapping for name resolution.
+func WithWindowNames(names map[string]string) Option {
+	return func(o *Options) {
+		o.WindowNames = names
+	}
+}
+
+// WithPaneNames sets the pane ID to name mapping for name resolution.
+func WithPaneNames(names map[string]string) Option {
+	return func(o *Options) {
+		o.PaneNames = names
 	}
 }
 

--- a/internal/search/regex.go
+++ b/internal/search/regex.go
@@ -39,30 +39,33 @@ func (p *RegexProvider) Match(notif notification.Notification, query string) boo
 
 	// Check each configured field
 	for _, field := range p.opts.Fields {
-		var fieldValue string
+		var fieldValues []string
 		switch field {
 		case "message":
-			fieldValue = notif.Message
+			fieldValues = []string{notif.Message}
 		case "session":
-			fieldValue = notif.Session
+			fieldValues = p.getFieldValuesWithNames(notif.Session, p.opts.SessionNames)
 		case "window":
-			fieldValue = notif.Window
+			fieldValues = p.getFieldValuesWithNames(notif.Window, p.opts.WindowNames)
 		case "pane":
-			fieldValue = notif.Pane
+			fieldValues = p.getFieldValuesWithNames(notif.Pane, p.opts.PaneNames)
 		case "level":
-			fieldValue = notif.Level
+			fieldValues = []string{notif.Level}
 		case "state":
-			fieldValue = notif.State
+			fieldValues = []string{notif.State}
 		}
 
-		// Skip empty fields
-		if fieldValue == "" {
-			continue
-		}
+		// Check all field values (ID and name)
+		for _, fieldValue := range fieldValues {
+			// Skip empty fields
+			if fieldValue == "" {
+				continue
+			}
 
-		// Check for regex match
-		if re.MatchString(fieldValue) {
-			return true
+			// Check for regex match
+			if re.MatchString(fieldValue) {
+				return true
+			}
 		}
 	}
 
@@ -102,4 +105,23 @@ func (p *RegexProvider) getRegex(pattern string) (*regexp.Regexp, error) {
 // Name returns the provider name.
 func (p *RegexProvider) Name() string {
 	return "regex"
+}
+
+// getFieldValuesWithNames returns a slice containing both the ID and resolved name.
+// If nameMap is nil or ID not found, returns only the ID.
+func (p *RegexProvider) getFieldValuesWithNames(id string, nameMap map[string]string) []string {
+	if id == "" {
+		return []string{}
+	}
+
+	values := []string{id}
+
+	// If name map is provided and ID exists in map, add the name
+	if nameMap != nil {
+		if name, ok := nameMap[id]; ok {
+			values = append(values, name)
+		}
+	}
+
+	return values
 }

--- a/internal/search/substring.go
+++ b/internal/search/substring.go
@@ -33,35 +33,38 @@ func (p *SubstringProvider) Match(notif notification.Notification, query string)
 
 	// Check each configured field
 	for _, field := range p.opts.Fields {
-		var fieldValue string
+		var fieldValues []string
 		switch field {
 		case "message":
-			fieldValue = notif.Message
+			fieldValues = []string{notif.Message}
 		case "session":
-			fieldValue = notif.Session
+			fieldValues = p.getFieldValuesWithNames(notif.Session, p.opts.SessionNames)
 		case "window":
-			fieldValue = notif.Window
+			fieldValues = p.getFieldValuesWithNames(notif.Window, p.opts.WindowNames)
 		case "pane":
-			fieldValue = notif.Pane
+			fieldValues = p.getFieldValuesWithNames(notif.Pane, p.opts.PaneNames)
 		case "level":
-			fieldValue = notif.Level
+			fieldValues = []string{notif.Level}
 		case "state":
-			fieldValue = notif.State
+			fieldValues = []string{notif.State}
 		}
 
-		// Skip empty fields
-		if fieldValue == "" {
-			continue
-		}
+		// Check all field values (ID and name)
+		for _, fieldValue := range fieldValues {
+			// Skip empty fields
+			if fieldValue == "" {
+				continue
+			}
 
-		// Apply case sensitivity
-		if p.opts.CaseInsensitive {
-			fieldValue = strings.ToLower(fieldValue)
-		}
+			// Apply case sensitivity
+			if p.opts.CaseInsensitive {
+				fieldValue = strings.ToLower(fieldValue)
+			}
 
-		// Check for substring match
-		if strings.Contains(fieldValue, searchQuery) {
-			return true
+			// Check for substring match
+			if strings.Contains(fieldValue, searchQuery) {
+				return true
+			}
 		}
 	}
 
@@ -71,4 +74,23 @@ func (p *SubstringProvider) Match(notif notification.Notification, query string)
 // Name returns the provider name.
 func (p *SubstringProvider) Name() string {
 	return "substring"
+}
+
+// getFieldValuesWithNames returns a slice containing both the ID and resolved name.
+// If nameMap is nil or ID not found, returns only the ID.
+func (p *SubstringProvider) getFieldValuesWithNames(id string, nameMap map[string]string) []string {
+	if id == "" {
+		return []string{}
+	}
+
+	values := []string{id}
+
+	// If name map is provided and ID exists in map, add the name
+	if nameMap != nil {
+		if name, ok := nameMap[id]; ok {
+			values = append(values, name)
+		}
+	}
+
+	return values
 }

--- a/internal/tmux/mock.go
+++ b/internal/tmux/mock.go
@@ -111,6 +111,26 @@ func (m *MockClient) GetSessionName(sessionID string) (string, error) {
 	return args.String(0), args.Error(1)
 }
 
+// ListWindows returns a mocked map of window IDs to names.
+// Configure the return value using:
+//
+//	windows := map[string]string{"@0": "main"}
+//	mock.On("ListWindows").Return(windows, nil)
+func (m *MockClient) ListWindows() (map[string]string, error) {
+	args := m.Called()
+	return args.Get(0).(map[string]string), args.Error(1)
+}
+
+// ListPanes returns a mocked map of pane IDs to names.
+// Configure the return value using:
+//
+//	panes := map[string]string{"%0": "terminal"}
+//	mock.On("ListPanes").Return(panes, nil)
+func (m *MockClient) ListPanes() (map[string]string, error) {
+	args := m.Called()
+	return args.Get(0).(map[string]string), args.Error(1)
+}
+
 // GetTmuxVisibility returns a mocked visibility state.
 // Configure the return value using:
 //

--- a/internal/tui/state/model_test.go
+++ b/internal/tui/state/model_test.go
@@ -41,6 +41,10 @@ func stubSessionFetchers(t *testing.T) *tmux.MockClient {
 	mockClient := new(tmux.MockClient)
 	// Mock ListSessions to return empty map
 	mockClient.On("ListSessions").Return(map[string]string{}, nil)
+	// Mock ListWindows to return empty map
+	mockClient.On("ListWindows").Return(map[string]string{}, nil)
+	// Mock ListPanes to return empty map
+	mockClient.On("ListPanes").Return(map[string]string{}, nil)
 
 	return mockClient
 }


### PR DESCRIPTION
…ndows, and panes

This enhancement allows users to search notifications using real names (e.g., 'my-work') instead of just internal IDs (e.g., '$1'), making search more intuitive and user-friendly.

Key changes:
- Enhanced provider interface to accept name resolution maps
- Modified all search providers (token, substring, regex) to match both IDs and names
- Added ListSessions/ListWindows/ListPanes methods to tmux client
- Updated TUI model to fetch and use name maps for search
- Enhanced CLI list command with transparent name-based search
- Added 30+ new test cases for comprehensive coverage

The implementation is backward compatible and maintains all existing functionality while adding the new name resolution capabilities transparently.