### PR TITLE
fix(tui): prevent TUI from closing on Enter in search mode

### DIFF
--- a/internal/tui/state/model.go
+++ b/internal/tui/state/model.go
@@ -113,6 +113,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 		case tea.KeyEnter:
+			if m.searchMode {
+				m.searchMode = false
+				return m, nil
+			}
 			if m.commandMode {
 				// Execute command
 				cmd := m.executeCommand()

--- a/internal/tui/state/model_test.go
+++ b/internal/tui/state/model_test.go
@@ -899,6 +899,18 @@ func TestModelUpdateHandlesSearchEscape(t *testing.T) {
 	assert.Equal(t, "", model.searchQuery)
 }
 
+func TestModelUpdateHandlesSearchEnter(t *testing.T) {
+	model := &Model{searchMode: true, searchQuery: "test query"}
+
+	msg := tea.KeyMsg{Type: tea.KeyEnter}
+	updated, cmd := model.Update(msg)
+	model = updated.(*Model)
+
+	assert.Nil(t, cmd)
+	assert.False(t, model.searchMode)
+	assert.Equal(t, "test query", model.searchQuery) // query should stay unchanged
+}
+
 // TestApplySearchFilterGroupedView tests that search filtering works correctly
 // in grouped view mode, including tree rebuilding and empty group pruning.
 func TestApplySearchFilterGroupedView(t *testing.T) {


### PR DESCRIPTION
## Summary
- Fixes bug where TUI would close when pressing Enter in search mode
- Adds guard clause to check if `searchMode` is active before handling Enter key
- Ensures TUI stays open and search filter is applied correctly

## Problem
When using TUI search:
1. User presses `/` to enter search mode
2. User types a search query
3. User presses Enter to apply search
4. **Expected:** Search is applied and user can navigate through filtered results
5. **Actual:** TUI closes completely

## Root Cause
The `tea.KeyEnter` handler in `internal/tui/state/model.go` did not check if `searchMode` was active. When in search mode, pressing Enter would trigger `handleJump()` which could return `tea.Quit` and close TUI instead of exiting search mode.

## Solution
Added a simple guard clause at the start of `tea.KeyEnter` handler:
```go
if m.searchMode {
    m.searchMode = false
    return m, nil
}
```

This ensures that when in search mode:
- Pressing Enter exits search mode
- TUI stays open
- Search filter is applied automatically

## Behavior Changes

**Before Fix ❌:**
```
User types search query
User presses Enter
→ TUI closes completely
→ User cannot use search functionality
```

**After Fix ✅:**
```
User types search query
User presses Enter
→ Search mode exits
→ Search filter is applied
→ TUI stays open
→ User can navigate through filtered results
```

## Testing
- ✅ All tests pass (Go + Bats)
- ✅ All linting passes
- ✅ Code is formatted
- ✅ Build succeeds
- ✅ Works with SQLite backend
- ✅ Compatible with all existing features

## Modified Files
- `internal/tui/state/model.go` - Added guard clause in `tea.KeyEnter` handler (lines 115-131)
- `internal/tui/state/model_test.go` - Added test for Enter in search mode

## Commit Details
**Commit Hash:** `f4b6acd`