### PR TITLE
chore: remove development artifacts and ignore *.tsv files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 # Temporary files
 *.tmp
 .tmp/
+*.tsv
 .DS_Store
 
 # Test artifacts

--- a/notifications.tsv
+++ b/notifications.tsv
@@ -1,3 +1,0 @@
-1	2026-02-04T07:20:01Z	active	session1	window0	pane0	Hello world		info
-2	2026-02-04T07:20:01Z	active	session1	window0	pane1	Warning: disk full		warning
-3	2026-02-04T07:20:01Z	active	session2	window1	pane2	Error: cannot connect		error

--- a/test_state/notifications.tsv
+++ b/test_state/notifications.tsv
@@ -1,6 +1,0 @@
-1	2026-02-04T07:22:12Z	active	session1	window0	pane0	Hello world		info
-2	2026-02-04T07:22:12Z	active	session1	window0	pane1	Warning: disk full		warning
-3	2026-02-04T07:22:12Z	active	session2	window1	pane2	Error: cannot connect		error
-4	2026-02-05T05:52:12Z	active				[2026-02-05 06:52:12] 'Test from Go CLI'		info
-2	2026-02-04T07:22:12Z	dismissed	session1	window0	pane1	Warning: disk full		warning
-5	2026-02-05T05:54:27Z	active	$3	@14	%21	[2026-02-05 06:54:27] 'Error test from Go'		error


### PR DESCRIPTION
## Summary

- Remove `notifications.tsv` (root-level development artifact)
- Remove `test_state/notifications.tsv` (development artifact)
- Add `*.tsv` to `.gitignore` to prevent future accidental commits

## Details

These files were accidentally committed during the Go CLI development (commit 9aa419d). They contain test data that was used during development but should not be in the repository since:

1. The default state directory is `~/.local/state/tmux-intray`, not the project root
2. All tests use `t.TempDir()` or set `TMUX_INTRAY_STATE_DIR` environment variable
3. No code references these root-level files
4. They contain test notification data that could be confusing to users

Adding `*.tsv` to `.gitignore` prevents future accidental commits of TSV files that may be created during local development or testing.