### PR TITLE
chore(dex): changed install target to build to ~/.local/bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,13 +115,15 @@ install:
 	@echo "Installing tmux-intray..."
 	@echo "  Version: $(VERSION)"
 	@echo "  Commit: $(COMMIT)"
-	go install $(LDFLAGS) ./cmd/tmux-intray
-	chmod +x scripts/lint.sh
-	chmod +x scripts/security-check.sh
-	chmod +x tmux-intray.tmux
-	chmod +x install.sh
+	@mkdir -p ~/.local/bin
+	go build $(LDFLAGS) -o ~/.local/bin/tmux-intray ./cmd/tmux-intray
+	@chmod +x ~/.local/bin/tmux-intray
+	@chmod +x scripts/lint.sh
+	@chmod +x scripts/security-check.sh
+	@chmod +x tmux-intray.tmux
+	@chmod +x install.sh
 	@echo "✓ Installation complete"
-	@echo "  - Go binary installed to: $$(go env GOPATH)/bin/tmux-intray"
+	@echo "  - Go binary installed to: ~/.local/bin/tmux-intray"
 
 
 install-npm:


### PR DESCRIPTION
This commit changes the install target to build the Go binary to ~/.local/bin instead of using go install.

Detailed Changes:
 - Implementation:
   - Changed the install target in Makefile to build the binary to ~/.local/bin.
 - Development Experience:
   - Updated the install target to create the ~/.local/bin directory and build the binary there.
   - Updated the success message to reflect the new binary location.