### PR TITLE
feat(tui): add gg/G navigation shortcuts

### DIFF
--- a/internal/tui/render/render.go
+++ b/internal/tui/render/render.go
@@ -209,6 +209,7 @@ func Footer(state FooterState) string {
 	var help []string
 	help = append(help, fmt.Sprintf("mode: %s", viewModeIndicator(state.ViewMode)))
 	help = append(help, "j/k: move")
+	help = append(help, "gg/G: top/bottom")
 	if state.SearchMode {
 		help = append(help, "ESC: exit search")
 		help = append(help, fmt.Sprintf("Search: %s", state.SearchQuery))

--- a/internal/tui/render/render_test.go
+++ b/internal/tui/render/render_test.go
@@ -178,6 +178,7 @@ func TestFooterGroupedHelpText(t *testing.T) {
 
 	assert.Contains(t, footer, "mode: [G]")
 	assert.Contains(t, footer, "v: cycle view mode")
+	assert.Contains(t, footer, "gg/G: top/bottom")
 	assert.Contains(t, footer, "h/l: collapse/expand")
 	assert.Contains(t, footer, "za: toggle fold")
 	assert.Contains(t, footer, "Enter: toggle/jump")

--- a/internal/tui/state/model.go
+++ b/internal/tui/state/model.go
@@ -113,6 +113,14 @@ func (m *Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.handleMoveDown()
 	case "k":
 		m.handleMoveUp()
+	case "G":
+		if !m.uiState.IsSearchMode() && !m.uiState.IsCommandMode() {
+			m.handleMoveBottom()
+		}
+	case "g":
+		if !m.uiState.IsSearchMode() && !m.uiState.IsCommandMode() {
+			m.uiState.SetPendingKey("g")
+		}
 	case "/":
 		m.handleSearchMode()
 	case ":":
@@ -154,7 +162,12 @@ func (m *Model) handlePendingKey(msg tea.KeyMsg) (bool, tea.Cmd) {
 			m.toggleFold()
 			return true, nil
 		}
-		if msg.String() != "z" {
+		if msg.String() == "g" && m.uiState.GetPendingKey() == "g" {
+			m.uiState.ClearPendingKey()
+			m.handleMoveTop()
+			return true, nil
+		}
+		if !(m.uiState.GetPendingKey() == "z" && msg.String() == "z") {
 			m.uiState.ClearPendingKey()
 		}
 	}
@@ -244,6 +257,26 @@ func (m *Model) handleMoveUp() {
 	m.uiState.MoveCursorUp(listLen)
 	m.updateViewportContent()
 	// Auto-scroll viewport if needed
+	m.uiState.EnsureCursorVisible(listLen)
+}
+
+func (m *Model) handleMoveTop() {
+	listLen := m.currentListLen()
+	if listLen == 0 {
+		return
+	}
+	m.uiState.SetCursor(0)
+	m.updateViewportContent()
+	m.uiState.EnsureCursorVisible(listLen)
+}
+
+func (m *Model) handleMoveBottom() {
+	listLen := m.currentListLen()
+	if listLen == 0 {
+		return
+	}
+	m.uiState.SetCursor(listLen - 1)
+	m.updateViewportContent()
 	m.uiState.EnsureCursorVisible(listLen)
 }
 


### PR DESCRIPTION
## Summary
- add vim-style `G` mapping to jump to the bottom in TUI list navigation
- add `gg` sequence mapping to jump to the top using existing pending-key handling
- update footer help text and tests to cover `gg`/`G` behavior and mode safety

## Testing
- make all
- go test ./...

Closes #136