### PR TITLE
chore: remove macOS from lint CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,10 +116,7 @@ jobs:
   #       run: npm test
 
   lint:
-    strategy:
-      matrix:
-        os: [macos-latest, ubuntu-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- Linting is OS-independent, so we're removing macOS from the lint job matrix to reduce CI resource usage.
- The change simplifies from running on both macOS and ubuntu-latest to only ubuntu-latest.
- All platform-specific testing remains intact (test jobs still run on both macOS and ubuntu-latest).

## Details

The lint job previously ran on both macOS and ubuntu-latest, but since linting tools (golangci-lint, shellcheck, shfmt) are platform-independent, we can run them only on ubuntu-latest without losing coverage. This reduces CI minutes and speeds up feedback cycles.

Platform-specific tests (Go tests, Bats integration tests) continue to run on both macOS and ubuntu-latest to ensure cross-platform compatibility.