### PR TITLE
refactor: clear and cleanup commands with dependency injection

### DIFF
--- a/cmd/tmux-intray/add.go
+++ b/cmd/tmux-intray/add.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2026 NAME HERE <EMAIL ADDRESS>
+Copyright © 2026 Cristian Oliveira <license@cristianoliveira.dev>
 */
 package main
 

--- a/cmd/tmux-intray/cleanup_test.go
+++ b/cmd/tmux-intray/cleanup_test.go
@@ -1,0 +1,210 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+var _ = (*cobra.Command)(nil)
+
+type fakeCleanupClient struct {
+	ensureTmuxRunningResult bool
+	ensureCalls             int
+	cleanupCalled           bool
+	cleanupErr              error
+	captured                struct {
+		days   int
+		dryRun bool
+	}
+}
+
+func (f *fakeCleanupClient) EnsureTmuxRunning() bool {
+	f.ensureCalls++
+	return f.ensureTmuxRunningResult
+}
+
+func (f *fakeCleanupClient) CleanupOldNotifications(days int, dryRun bool) error {
+	f.cleanupCalled = true
+	f.captured.days = days
+	f.captured.dryRun = dryRun
+	return f.cleanupErr
+}
+
+func TestNewCleanupCmdPanicsWhenClientIsNil(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatalf("expected panic, got nil")
+		}
+		msg, ok := r.(string)
+		if !ok {
+			t.Fatalf("expected panic message as string, got %T", r)
+		}
+		if !strings.Contains(msg, "client dependency cannot be nil") {
+			t.Fatalf("expected panic message to mention nil dependency, got %q", msg)
+		}
+	}()
+
+	NewCleanupCmd(nil)
+}
+
+func TestCleanupCmdRunETmuxNotRunningError(t *testing.T) {
+	t.Setenv("TMUX_INTRAY_AUTO_CLEANUP_DAYS", "30")
+	client := &fakeCleanupClient{ensureTmuxRunningResult: false}
+	cmd := NewCleanupCmd(client)
+
+	output := &bytes.Buffer{}
+	cmd.SetOut(output)
+	cmd.SetErr(output)
+
+	err := cmd.RunE(cmd, []string{})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "no tmux session running") {
+		t.Fatalf("expected error about tmux, got %q", err.Error())
+	}
+	if client.ensureCalls != 1 {
+		t.Fatalf("expected EnsureTmuxRunning to be called once, got %d", client.ensureCalls)
+	}
+	if client.cleanupCalled {
+		t.Fatal("expected CleanupOldNotifications not to be called")
+	}
+}
+
+func TestCleanupCmdRunESuccessWithDefaultDays(t *testing.T) {
+	t.Setenv("TMUX_INTRAY_AUTO_CLEANUP_DAYS", "45")
+	client := &fakeCleanupClient{ensureTmuxRunningResult: true}
+	cmd := NewCleanupCmd(client)
+
+	output := &bytes.Buffer{}
+	cmd.SetOut(output)
+	cmd.SetErr(output)
+
+	err := cmd.RunE(cmd, []string{})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if client.ensureCalls != 1 {
+		t.Fatalf("expected EnsureTmuxRunning to be called once, got %d", client.ensureCalls)
+	}
+	if !client.cleanupCalled {
+		t.Fatal("expected CleanupOldNotifications to be called")
+	}
+	if client.captured.days != 45 {
+		t.Fatalf("expected days=45, got %d", client.captured.days)
+	}
+	if client.captured.dryRun {
+		t.Fatal("expected dryRun=false")
+	}
+	// Check that output contains expected message
+	if !strings.Contains(output.String(), "Starting cleanup of notifications dismissed more than 45 days ago") {
+		t.Fatalf("expected output to contain cleanup message, got %q", output.String())
+	}
+	if !strings.Contains(output.String(), "Cleanup completed") {
+		t.Fatalf("expected output to contain completion message, got %q", output.String())
+	}
+}
+
+func TestCleanupCmdRunESuccessWithDaysFlag(t *testing.T) {
+	client := &fakeCleanupClient{ensureTmuxRunningResult: true}
+	cmd := NewCleanupCmd(client)
+	setFlag(t, cmd, "days", "7")
+
+	output := &bytes.Buffer{}
+	cmd.SetOut(output)
+	cmd.SetErr(output)
+
+	err := cmd.RunE(cmd, []string{})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if client.captured.days != 7 {
+		t.Fatalf("expected days=7, got %d", client.captured.days)
+	}
+}
+
+func TestCleanupCmdRunEWithDryRun(t *testing.T) {
+	client := &fakeCleanupClient{ensureTmuxRunningResult: true}
+	cmd := NewCleanupCmd(client)
+	setFlag(t, cmd, "dryrun", "true")
+
+	output := &bytes.Buffer{}
+	cmd.SetOut(output)
+	cmd.SetErr(output)
+
+	err := cmd.RunE(cmd, []string{})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !client.captured.dryRun {
+		t.Fatal("expected dryRun=true")
+	}
+}
+
+func TestCleanupCmdRunEDaysZeroUsesConfig(t *testing.T) {
+	t.Setenv("TMUX_INTRAY_AUTO_CLEANUP_DAYS", "99")
+	client := &fakeCleanupClient{ensureTmuxRunningResult: true}
+	cmd := NewCleanupCmd(client)
+	setFlag(t, cmd, "days", "0")
+
+	output := &bytes.Buffer{}
+	cmd.SetOut(output)
+	cmd.SetErr(output)
+
+	err := cmd.RunE(cmd, []string{})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if client.captured.days != 99 {
+		t.Fatalf("expected days=99 from config, got %d", client.captured.days)
+	}
+}
+
+func TestCleanupCmdRunEDaysNegativeError(t *testing.T) {
+	client := &fakeCleanupClient{ensureTmuxRunningResult: true}
+	cmd := NewCleanupCmd(client)
+	setFlag(t, cmd, "days", "-5")
+
+	output := &bytes.Buffer{}
+	cmd.SetOut(output)
+	cmd.SetErr(output)
+
+	err := cmd.RunE(cmd, []string{})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "days must be a positive integer") {
+		t.Fatalf("expected error about positive integer, got %q", err.Error())
+	}
+	if client.cleanupCalled {
+		t.Fatal("expected CleanupOldNotifications not to be called")
+	}
+}
+
+func TestCleanupCmdRunECleanupError(t *testing.T) {
+	client := &fakeCleanupClient{
+		ensureTmuxRunningResult: true,
+		cleanupErr:              errors.New("storage error"),
+	}
+	cmd := NewCleanupCmd(client)
+
+	output := &bytes.Buffer{}
+	cmd.SetOut(output)
+	cmd.SetErr(output)
+
+	err := cmd.RunE(cmd, []string{})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "cleanup failed: storage error") {
+		t.Fatalf("expected wrapped cleanup error, got %q", err.Error())
+	}
+	if !client.cleanupCalled {
+		t.Fatal("expected CleanupOldNotifications to be called")
+	}
+}

--- a/cmd/tmux-intray/clear.go
+++ b/cmd/tmux-intray/clear.go
@@ -10,16 +10,24 @@ import (
 	"strings"
 
 	"github.com/cristianoliveira/tmux-intray/cmd"
-
 	"github.com/cristianoliveira/tmux-intray/internal/colors"
 	"github.com/spf13/cobra"
 )
 
-// clearCmd represents the clear command
-var clearCmd = &cobra.Command{
-	Use:   "clear",
-	Short: "Clear all items from the tray",
-	Long: `Clear all active notifications from the tray.
+type clearClient interface {
+	ClearTrayItems() error
+}
+
+// NewClearCmd creates the clear command with explicit dependencies.
+func NewClearCmd(client clearClient) *cobra.Command {
+	if client == nil {
+		panic("NewClearCmd: client dependency cannot be nil")
+	}
+
+	clearCmd := &cobra.Command{
+		Use:   "clear",
+		Short: "Clear all items from the tray",
+		Long: `Clear all active notifications from the tray.
 
 This command dismisses all active notifications, running pre-clear and per-notification
 hooks, and updates the tmux status option.
@@ -33,7 +41,42 @@ ALIAS:
 EXAMPLES:
     # Clear all active notifications
     tmux-intray clear`,
-	Run: runClear,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Skip confirmation if running in CI or test environment
+			if allowTmuxlessMode() {
+				// In CI/test mode, proceed without confirmation
+				err := client.ClearTrayItems()
+				if err != nil {
+					return fmt.Errorf("clear: failed to clear tray items: %w", err)
+				}
+				colors.Success("cleared")
+				return nil
+			}
+
+			// Ask for confirmation
+			if !confirmClearAll() {
+				colors.Info("Operation cancelled")
+				return nil
+			}
+
+			err := client.ClearTrayItems()
+			if err != nil {
+				return fmt.Errorf("clear: failed to clear tray items: %w", err)
+			}
+			colors.Success("Tray cleared")
+			return nil
+		},
+	}
+
+	return clearCmd
+}
+
+// clearCmd represents the clear command.
+var clearCmd = NewClearCmd(coreClient)
+
+func init() {
+	cmd.RootCmd.AddCommand(clearCmd)
 }
 
 var clearAllFunc = func() error {
@@ -42,37 +85,6 @@ var clearAllFunc = func() error {
 
 func ClearAll() error {
 	return clearAllFunc()
-}
-
-func init() {
-	cmd.RootCmd.AddCommand(clearCmd)
-}
-
-func runClear(cmd *cobra.Command, args []string) {
-	// Skip confirmation if running in CI or test environment
-	if os.Getenv("CI") != "" || os.Getenv("BATS_TMPDIR") != "" {
-		// In CI/test mode, proceed without confirmation
-		err := ClearAll()
-		if err != nil {
-			colors.Error(err.Error())
-			return
-		}
-		colors.Success("cleared")
-		return
-	}
-
-	// Ask for confirmation
-	if !confirmClearAll() {
-		colors.Info("Operation cancelled")
-		return
-	}
-	// Run clear operation
-	err := ClearAll()
-	if err != nil {
-		colors.Error(err.Error())
-		return
-	}
-	colors.Success("Tray cleared")
 }
 
 // confirmClearAll asks the user for confirmation before clearing all notifications.

--- a/cmd/tmux-intray/clear_test.go
+++ b/cmd/tmux-intray/clear_test.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"bytes"
 	"errors"
+	"os"
+	"strings"
 	"testing"
 )
 
@@ -53,5 +56,198 @@ func TestClearAllMultipleCalls(t *testing.T) {
 	_ = ClearAll()
 	if count != 2 {
 		t.Errorf("Expected clearAllFunc to be called 2 times, got %d", count)
+	}
+}
+
+type fakeClearClient struct {
+	clearCalled bool
+	clearErr    error
+}
+
+func (f *fakeClearClient) ClearTrayItems() error {
+	f.clearCalled = true
+	return f.clearErr
+}
+
+func TestNewClearCmdPanicsWhenClientIsNil(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatalf("expected panic, got nil")
+		}
+		msg, ok := r.(string)
+		if !ok {
+			t.Fatalf("expected panic message as string, got %T", r)
+		}
+		if !strings.Contains(msg, "client dependency cannot be nil") {
+			t.Fatalf("expected panic message to mention nil dependency, got %q", msg)
+		}
+	}()
+
+	NewClearCmd(nil)
+}
+
+func TestClearCmdRunESuccessWithTmuxlessMode(t *testing.T) {
+	t.Setenv("TMUX_INTRAY_ALLOW_NO_TMUX", "true")
+	client := &fakeClearClient{}
+	cmd := NewClearCmd(client)
+
+	output := &bytes.Buffer{}
+	cmd.SetOut(output)
+	cmd.SetErr(output)
+
+	err := cmd.RunE(cmd, []string{})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !client.clearCalled {
+		t.Fatal("expected ClearTrayItems to be called")
+	}
+}
+
+func TestClearCmdRunEErrorWithTmuxlessMode(t *testing.T) {
+	t.Setenv("TMUX_INTRAY_ALLOW_NO_TMUX", "true")
+	expectedErr := errors.New("storage error")
+	client := &fakeClearClient{clearErr: expectedErr}
+	cmd := NewClearCmd(client)
+
+	output := &bytes.Buffer{}
+	cmd.SetOut(output)
+	cmd.SetErr(output)
+
+	err := cmd.RunE(cmd, []string{})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "clear: failed to clear tray items") {
+		t.Fatalf("expected error to contain 'clear: failed to clear tray items', got %q", err.Error())
+	}
+	if !client.clearCalled {
+		t.Fatal("expected ClearTrayItems to be called")
+	}
+}
+
+func TestClearCmdRunEWithConfirmationYes(t *testing.T) {
+	// Ensure tmuxless mode is false
+	t.Setenv("TMUX_INTRAY_ALLOW_NO_TMUX", "")
+	t.Setenv("CI", "")
+	t.Setenv("BATS_TMPDIR", "")
+	t.Setenv("TMUX_AVAILABLE", "")
+
+	// Mock stdin with "y\n"
+	oldStdin := os.Stdin
+	r, w, _ := os.Pipe()
+	defer func() { os.Stdin = oldStdin }()
+	os.Stdin = r
+	go func() {
+		w.Write([]byte("y\n"))
+		w.Close()
+	}()
+
+	client := &fakeClearClient{}
+	cmd := NewClearCmd(client)
+
+	output := &bytes.Buffer{}
+	cmd.SetOut(output)
+	cmd.SetErr(output)
+
+	err := cmd.RunE(cmd, []string{})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !client.clearCalled {
+		t.Fatal("expected ClearTrayItems to be called")
+	}
+}
+
+func TestClearCmdRunEWithConfirmationNo(t *testing.T) {
+	t.Setenv("TMUX_INTRAY_ALLOW_NO_TMUX", "")
+	t.Setenv("CI", "")
+	t.Setenv("BATS_TMPDIR", "")
+	t.Setenv("TMUX_AVAILABLE", "")
+
+	oldStdin := os.Stdin
+	r, w, _ := os.Pipe()
+	defer func() { os.Stdin = oldStdin }()
+	os.Stdin = r
+	go func() {
+		w.Write([]byte("n\n"))
+		w.Close()
+	}()
+
+	client := &fakeClearClient{}
+	cmd := NewClearCmd(client)
+
+	output := &bytes.Buffer{}
+	cmd.SetOut(output)
+	cmd.SetErr(output)
+
+	err := cmd.RunE(cmd, []string{})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if client.clearCalled {
+		t.Fatal("expected ClearTrayItems not to be called")
+	}
+}
+
+func TestConfirmClearAllYes(t *testing.T) {
+	oldStdin := os.Stdin
+	r, w, _ := os.Pipe()
+	defer func() { os.Stdin = oldStdin }()
+	os.Stdin = r
+	go func() {
+		w.Write([]byte("y\n"))
+		w.Close()
+	}()
+
+	result := confirmClearAll()
+	if !result {
+		t.Fatal("expected confirmClearAll to return true for 'y'")
+	}
+}
+
+func TestConfirmClearAllNo(t *testing.T) {
+	oldStdin := os.Stdin
+	r, w, _ := os.Pipe()
+	defer func() { os.Stdin = oldStdin }()
+	os.Stdin = r
+	go func() {
+		w.Write([]byte("n\n"))
+		w.Close()
+	}()
+
+	result := confirmClearAll()
+	if result {
+		t.Fatal("expected confirmClearAll to return false for 'n'")
+	}
+}
+
+func TestConfirmClearAllEmptyInput(t *testing.T) {
+	oldStdin := os.Stdin
+	r, w, _ := os.Pipe()
+	defer func() { os.Stdin = oldStdin }()
+	os.Stdin = r
+	go func() {
+		w.Write([]byte("\n"))
+		w.Close()
+	}()
+
+	result := confirmClearAll()
+	if result {
+		t.Fatal("expected confirmClearAll to return false for empty input")
+	}
+}
+
+func TestConfirmClearAllReadError(t *testing.T) {
+	oldStdin := os.Stdin
+	r, w, _ := os.Pipe()
+	os.Stdin = r
+	w.Close() // Close write side to cause read error
+	defer func() { os.Stdin = oldStdin }()
+
+	result := confirmClearAll()
+	if result {
+		t.Fatal("expected confirmClearAll to return false on read error")
 	}
 }

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -101,6 +101,16 @@ func (c *Core) ClearTrayItems() error {
 	return c.storage.DismissAll()
 }
 
+// CleanupOldNotifications cleans up old dismissed notifications.
+func CleanupOldNotifications(days int, dryRun bool) error {
+	return defaultCore.CleanupOldNotifications(days, dryRun)
+}
+
+// CleanupOldNotifications cleans up old dismissed notifications using this Core instance.
+func (c *Core) CleanupOldNotifications(days int, dryRun bool) error {
+	return c.storage.CleanupOldNotifications(days, dryRun)
+}
+
 // MarkNotificationRead marks a notification as read.
 func MarkNotificationRead(id string) error {
 	return defaultCore.MarkNotificationRead(id)


### PR DESCRIPTION
Applied dependency injection pattern from add.go to clear.go and cleanup.go. Added client interfaces, factory functions, and comprehensive tests.