### PR TITLE
chore(install): copy binary to GOPATH bin directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,8 @@ clean:
 	@echo "Cleaning..."
 	rm -rf bin/tmux-intray
 
+GOPATH := $(shell go env GOPATH)
+
 install:
 	@echo "Installing tmux-intray..."
 	@echo "  Version: $(VERSION)"
@@ -123,12 +125,15 @@ install:
 	@mkdir -p ~/.local/bin
 	go build $(LDFLAGS) -o ~/.local/bin/tmux-intray ./cmd/tmux-intray
 	@chmod +x ~/.local/bin/tmux-intray
+	@mkdir -p $(GOPATH)/bin
+	@cp ~/.local/bin/tmux-intray $(GOPATH)/bin/tmux-intray
 	@chmod +x scripts/lint.sh
 	@chmod +x scripts/security-check.sh
 	@chmod +x tmux-intray.tmux
 	@chmod +x install.sh
 	@echo "✓ Installation complete"
 	@echo "  - Go binary installed to: ~/.local/bin/tmux-intray"
+	@echo "  - Go binary installed to: $(GOPATH)/bin/tmux-intray"
 
 
 install-npm:


### PR DESCRIPTION
This commit changes the install target to copy the built binary to both ~/.local/bin and $(GOPATH)/bin. Detailed Changes:
 - Implementation:
   - Added GOPATH variable to Makefile.
   - Changed install target to copy binary to $(GOPATH)/bin in addition to ~/.local/bin.
   - Updated install completion message to list both binary locations.