### PR TITLE
refactor(cmd): apply add command pattern to version with improved test coverage

### DIFF
--- a/cmd/tmux-intray/version.go
+++ b/cmd/tmux-intray/version.go
@@ -1,33 +1,41 @@
+/*
+Copyright © 2026 Cristian Oliveira <license@cristianoliveira.dev>
+*/
 package main
 
 import (
 	"fmt"
-	"io"
-	"os"
 
 	"github.com/cristianoliveira/tmux-intray/cmd"
-	"github.com/cristianoliveira/tmux-intray/internal/version"
-
 	"github.com/spf13/cobra"
 )
 
-// versionOutputWriter is the writer used by PrintVersion. Can be changed for testing.
-var versionOutputWriter io.Writer = os.Stdout
+type versionClient interface {
+	Version() string
+}
 
-// PrintVersion prints the version information to stdout.
-func PrintVersion() {
-	fmt.Fprintf(versionOutputWriter, "tmux-intray version %s\n", version.String())
+// NewVersionCmd creates the version command with explicit dependencies.
+func NewVersionCmd(client versionClient) *cobra.Command {
+	if client == nil {
+		panic("NewVersionCmd: client dependency cannot be nil")
+	}
+
+	versionCmd := &cobra.Command{
+		Use:   "version",
+		Short: "Show version information",
+		Long:  `Show the current version of tmux-intray.`,
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fmt.Fprintf(cmd.OutOrStdout(), "tmux-intray version %s\n", client.Version())
+			return nil
+		},
+	}
+
+	return versionCmd
 }
 
 // versionCmd represents the version command
-var versionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "Show version information",
-	Long:  `Show the current version of tmux-intray.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		PrintVersion()
-	},
-}
+var versionCmd = NewVersionCmd(coreClient)
 
 func init() {
 	cmd.RootCmd.AddCommand(versionCmd)

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -7,12 +7,23 @@ import (
 
 	"github.com/cristianoliveira/tmux-intray/internal/settings"
 	"github.com/cristianoliveira/tmux-intray/internal/storage"
+	"github.com/cristianoliveira/tmux-intray/internal/version"
 )
 
 // GetTrayItems returns tray items for a given state filter.
 // Returns newline-separated messages (unescaped).
 func GetTrayItems(stateFilter string) (string, error) {
 	return defaultCore.GetTrayItems(stateFilter)
+}
+
+// Version returns the version string.
+func Version() string {
+	return defaultCore.Version()
+}
+
+// Version returns the version string using this Core instance.
+func (c *Core) Version() string {
+	return version.String()
 }
 
 // GetTrayItems returns tray items for a given state filter using this Core instance.


### PR DESCRIPTION
## Summary
This PR refactors the version command to follow the same dependency injection pattern used in the add command, improving testability and code consistency.

### Pattern Applied
- **Client interface** for dependency injection (versionClient)
- **Factory function** with nil client validation (NewVersionCmd())
- **RunE** for proper error handling in Cobra commands

### Changes
- cmd/tmux-intray/version.go - Refactored with versionClient interface, NewVersionCmd factory, RunE pattern
- cmd/tmux-intray/version_test.go - Added comprehensive unit tests covering the version command functionality
- internal/core/core.go - Added Version() method to the core interface

### Test Coverage
- TestNewVersionCmdPanicsWhenClientIsNil - nil client validation
- Table-driven tests for version output

## Test Plan
- [x] All Go tests pass (go test ./...)
- [x] Lint checks pass (make lint)
- [x] Code builds successfully (go build ./...)