### PR TITLE
chore(license): update copyright holder to Cristian Oliveira

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2026 NAME HERE <EMAIL ADDRESS>
+Copyright © 2026 Cristian Oliveira <license@cristianoliveira.dev>
 */
 package cmd
 

--- a/cmd/tmux-intray/cleanup.go
+++ b/cmd/tmux-intray/cleanup.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2026 NAME HERE <EMAIL ADDRESS>
+Copyright © 2026 Cristian Oliveira <license@cristianoliveira.dev>
 */
 package main
 

--- a/cmd/tmux-intray/clear.go
+++ b/cmd/tmux-intray/clear.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2026 NAME HERE <EMAIL ADDRESS>
+Copyright © 2026 Cristian Oliveira <license@cristianoliveira.dev>
 */
 package main
 

--- a/cmd/tmux-intray/dismiss.go
+++ b/cmd/tmux-intray/dismiss.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2026 NAME HERE <EMAIL ADDRESS>
+Copyright © 2026 Cristian Oliveira <license@cristianoliveira.dev>
 */
 package main
 

--- a/cmd/tmux-intray/follow.go
+++ b/cmd/tmux-intray/follow.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2026 NAME HERE <EMAIL ADDRESS>
+Copyright © 2026 Cristian Oliveira <license@cristianoliveira.dev>
 */
 package main
 

--- a/cmd/tmux-intray/jump.go
+++ b/cmd/tmux-intray/jump.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2026 NAME HERE <EMAIL ADDRESS>
+Copyright © 2026 Cristian Oliveira <license@cristianoliveira.dev>
 */
 package main
 

--- a/cmd/tmux-intray/list.go
+++ b/cmd/tmux-intray/list.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2026 NAME HERE <EMAIL ADDRESS>
+Copyright © 2026 Cristian Oliveira <license@cristianoliveira.dev>
 */
 package main
 

--- a/cmd/tmux-intray/mark-read.go
+++ b/cmd/tmux-intray/mark-read.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2026 NAME HERE <EMAIL ADDRESS>
+Copyright © 2026 Cristian Oliveira <license@cristianoliveira.dev>
 */
 package main
 

--- a/cmd/tmux-intray/settings.go
+++ b/cmd/tmux-intray/settings.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2026 NAME HERE <EMAIL ADDRESS>
+Copyright © 2026 Cristian Oliveira <license@cristianoliveira.dev>
 */
 package main
 

--- a/cmd/tmux-intray/status-panel.go
+++ b/cmd/tmux-intray/status-panel.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2026 NAME HERE <EMAIL ADDRESS>
+Copyright © 2026 Cristian Oliveira <license@cristianoliveira.dev>
 */
 package main
 

--- a/cmd/tmux-intray/status.go
+++ b/cmd/tmux-intray/status.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2026 NAME HERE <EMAIL ADDRESS>
+Copyright © 2026 Cristian Oliveira <license@cristianoliveira.dev>
 */
 package main
 

--- a/cmd/tmux-intray/tui.go
+++ b/cmd/tmux-intray/tui.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2026 NAME HERE <EMAIL ADDRESS>
+Copyright © 2026 Cristian Oliveira <license@cristianoliveira.dev>
 */
 package main
 


### PR DESCRIPTION
This commit updates the copyright holder from 'NAME HERE <EMAIL ADDRESS>' to 'Cristian Oliveira <license@cristianoliveira.dev>' in multiple command files. Detailed Changes:
 - Documentation:
   - cmd/root.go: changed copyright holder.
   - cmd/tmux-intray/cleanup.go: changed copyright holder.
   - cmd/tmux-intray/clear.go: changed copyright holder.
   - cmd/tmux-intray/dismiss.go: changed copyright holder.
   - cmd/tmux-intray/follow.go: changed copyright holder.
   - cmd/tmux-intray/jump.go: changed copyright holder.
   - cmd/tmux-intray/list.go: changed copyright holder.
   - cmd/tmux-intray/mark-read.go: changed copyright holder.
   - cmd/tmux-intray/settings.go: changed copyright holder.
   - cmd/tmux-intray/status-panel.go: changed copyright holder.
   - cmd/tmux-intray/status.go: changed copyright holder.
   - cmd/tmux-intray/tui.go: changed copyright holder.