### PR TITLE
refactor(cmd): replace orderUnreadFirst with domain.SortByReadStatus

### DIFF
--- a/cmd/tmux-intray/list_test.go
+++ b/cmd/tmux-intray/list_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cristianoliveira/tmux-intray/internal/domain"
 	"github.com/cristianoliveira/tmux-intray/internal/notification"
 	"github.com/cristianoliveira/tmux-intray/internal/search"
 	"github.com/stretchr/testify/assert"
@@ -532,6 +533,17 @@ func (f *fakeListClient) ListNotifications(stateFilter, levelFilter, sessionFilt
 }
 
 func TestOrderUnreadFirstEdgeCases(t *testing.T) {
+	// Helper to replace the removed orderUnreadFirst function
+	orderUnreadFirst := func(notifs []notification.Notification) []notification.Notification {
+		if len(notifs) == 0 {
+			return notifs
+		}
+		domainNotifs := notification.ToDomainSliceUnsafe(notifs)
+		values := notificationsToValues(domainNotifs)
+		sorted := domain.SortByReadStatus(values, domain.SortOrderAsc)
+		return notification.FromDomainSlice(notificationsToPointers(sorted))
+	}
+
 	// Empty slice
 	empty := []notification.Notification{}
 	result := orderUnreadFirst(empty)


### PR DESCRIPTION
## Summary
- Replaced custom `orderUnreadFirst` with `domain.SortByReadStatus` for unread-first ordering
- Updated list tests to match the new domain-based sort logic
- Removed local sorting helper to reduce duplication

## Changes Made
- `cmd/tmux-intray/list.go`: use domain sorting for unread-first
- `cmd/tmux-intray/list_test.go`: updated test helper for sorting

## Test Plan
- [x] All list tests pass
- [x] All Go tests pass
- [x] Lint passes