### PR TITLE
ci: enforce strict linting in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
         run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.8.0
 
       - name: Run lint
-        run: make lint
+        run: make lint-strict
 
       - name: Run security check
         run: make security-check

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,15 +2,8 @@
 # Focus on complexity metrics with conservative thresholds for existing codebase
 version: "2"
 
-run:
-  # Default timeout for analysis
-  timeout: 5m
-
-
-
-# Linter settings
 linters:
-  # Enable specific linters
+  default: none
   enable:
     - gocyclo      # Cyclomatic complexity
     - gocognit     # Cognitive complexity
@@ -18,63 +11,41 @@ linters:
     - nestif       # Nested if statements
     - staticcheck  # Static analysis
     - errcheck     # Error checking
-  
-  # Disable default linters we don't want
   disable:
     - govet
     - unused
     - ineffassign
     - revive
-
-# Linter-specific configuration (using default thresholds for now)
-linters-settings:
-  gocyclo:
-    min-complexity: 20
-  gocognit:
-    min-complexity: 30
-  funlen:
-    lines: 80
-    statements: 50
-  nestif:
-    min-complexity: 5
-
-# Severity settings
-issues:
-  # Maximum allowed issues with same text (0 = unlimited)
-  max-same: 0
-  # Maximum allowed issues (0 = unlimited)
-  max: 0
-  # Exclude generated files
-  exclude-generated: true
-  # Exclude files with default patterns
-  exclude-files:
-    - ".*_gen\\.go$"
-    - "integration/.*\\.go$"
-  exclude-dirs:
-    - .tmp
-    - .gwt
-    - .bv
-    - .local
-    - tmp
-    - vendor
-    - integration
-    - integration/cmd
-  # Exclude rules
-  exclude-rules:
-    # Exclude errcheck and funlen for test files (common to ignore errors in tests)
-    - path: _test\.go
-      linters:
-        - errcheck
-        - funlen
-    # Exclude gocyclo for generated files
-    - path: _gen\.go
-      linters:
-        - gocyclo
-        - gocognit
-        - funlen
-
-# Output format
-output:
-  format: colored-line-number
-  print-issued-lines: true
-  print-linter-name: true
+  settings:
+    gocyclo:
+      min-complexity: 20
+    gocognit:
+      min-complexity: 30
+    funlen:
+      lines: 80
+      statements: 50
+    nestif:
+      min-complexity: 5
+  exclusions:
+    presets: []
+    paths:
+      - .tmp
+      - .gwt
+      - .bv
+      - .local
+      - tmp
+      - vendor
+      - integration
+      - integration/cmd
+      - ".*_gen\\.go$"
+      - "integration/.*\\.go$"
+    rules:
+      - path: (.+)_test\.go
+        linters:
+          - errcheck
+          - funlen
+      - path: (.+)_gen\.go
+        linters:
+          - gocyclo
+          - gocognit
+          - funlen

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,10 @@ go-complexity-lint:
 	@echo "Running Go complexity linting with golangci-lint..."
 	golangci-lint run --issues-exit-code=0
 
+go-complexity-lint-strict:
+	@echo "Running Go complexity linting with golangci-lint (strict)..."
+	golangci-lint run
+
 go-cover:
 	@echo "Running Go test coverage..."
 	go test ./... -coverprofile=coverage.out
@@ -90,6 +94,10 @@ go-build:
 
 lint: check-fmt go-lint go-complexity-lint
 	@echo "Running linter..."
+	./scripts/lint.sh
+
+lint-strict: check-fmt go-lint go-complexity-lint-strict
+	@echo "Running strict linter..."
 	./scripts/lint.sh
 
 docs:


### PR DESCRIPTION
Summary: CI now fails on lint errors. Added lint-strict target, updated .golangci.yml to v2.8.0 schema. Beads task: tmux-intray-0uzr.