### PR TITLE
feat(settings): allow group_by=message in settings/config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -176,7 +176,7 @@ expansionState = {}
 | `filters.window` | string | Filter by tmux window | `""` (no filter) | Window ID or `""` |
 | `filters.pane` | string | Filter by tmux pane | `""` (no filter) | Pane ID or `""` |
 | `viewMode` | string | Display layout | `"grouped"` | `"compact"`, `"detailed"`, `"grouped"` |
-| `groupBy` | string | Group notifications in the TUI | `"none"` | `"none"`, `"session"`, `"window"`, `"pane"` |
+| `groupBy` | string | Group notifications in the TUI | `"none"` | `"none"`, `"session"`, `"window"`, `"pane"`, `"message"` |
 | `defaultExpandLevel` | number | Default grouping expansion depth | `1` | `0`-`3` |
 | `expansionState` | object | Explicit expansion overrides by node path | `{}` | Object of string to boolean |
 
@@ -186,6 +186,7 @@ expansionState = {}
 - `session`: session groups with notifications directly under each session
 - `window`: session -> window -> notification
 - `pane`: session -> window -> pane -> notification
+- `message`: groups notifications by message text (exact match)
 
 ### Default Settings
 

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -81,6 +81,7 @@ const (
 	GroupBySession = "session"
 	GroupByWindow  = "window"
 	GroupByPane    = "pane"
+	GroupByMessage = "message"
 )
 
 // Expansion level limits.
@@ -174,7 +175,7 @@ type Settings struct {
 	// Empty string means use default view mode (grouped).
 	ViewMode string
 
-	// GroupBy specifies the grouping mode: "none", "session", "window", or "pane".
+	// GroupBy specifies the grouping mode: "none", "session", "window", "pane", or "message".
 	// Empty string means use default grouping (none).
 	GroupBy string
 
@@ -458,7 +459,7 @@ func Validate(settings *Settings) error {
 // IsValidGroupBy returns true if groupBy is a supported grouping mode.
 func IsValidGroupBy(groupBy string) bool {
 	switch groupBy {
-	case GroupByNone, GroupBySession, GroupByWindow, GroupByPane:
+	case GroupByNone, GroupBySession, GroupByWindow, GroupByPane, GroupByMessage:
 		return true
 	default:
 		return false

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -389,6 +389,17 @@ func TestValidateValidSettings(t *testing.T) {
 				GroupBy:   "",
 			},
 		},
+		{
+			name: "group by message",
+			settings: &Settings{
+				Columns:            DefaultColumns,
+				SortBy:             SortByTimestamp,
+				SortOrder:          SortOrderDesc,
+				ViewMode:           ViewModeGrouped,
+				GroupBy:            GroupByMessage,
+				DefaultExpandLevel: 1,
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/tui/service/command_service.go
+++ b/internal/tui/service/command_service.go
@@ -227,12 +227,12 @@ type GroupByCommandHandler struct {
 
 func (h *GroupByCommandHandler) Execute(args []string) (*model.CommandResult, error) {
 	if len(args) != 1 {
-		return &model.CommandResult{Error: true, Message: "Invalid usage: group-by <none|session|window|pane>"}, nil
+		return &model.CommandResult{Error: true, Message: "Invalid usage: group-by <none|session|window|pane|message>"}, nil
 	}
 
 	groupBy := strings.ToLower(args[0])
 	if !settings.IsValidGroupBy(groupBy) {
-		msg := fmt.Sprintf("Invalid group-by value: %s (expected one of: none, session, window, pane)", args[0])
+		msg := fmt.Sprintf("Invalid group-by value: %s (expected one of: none, session, window, pane, message)", args[0])
 		return &model.CommandResult{Error: true, Message: msg}, nil
 	}
 
@@ -258,12 +258,12 @@ func (h *GroupByCommandHandler) Execute(args []string) (*model.CommandResult, er
 
 func (h *GroupByCommandHandler) Validate(args []string) error {
 	if len(args) != 1 {
-		return fmt.Errorf("invalid usage: group-by <none|session|window|pane>")
+		return fmt.Errorf("invalid usage: group-by <none|session|window|pane|message>")
 	}
 
 	groupBy := strings.ToLower(args[0])
 	if !settings.IsValidGroupBy(groupBy) {
-		return fmt.Errorf("invalid group-by value: %s (expected one of: none, session, window, pane)", args[0])
+		return fmt.Errorf("invalid group-by value: %s (expected one of: none, session, window, pane, message)", args[0])
 	}
 
 	return nil
@@ -271,7 +271,7 @@ func (h *GroupByCommandHandler) Validate(args []string) error {
 
 func (h *GroupByCommandHandler) Complete(args []string) []string {
 	if len(args) == 0 {
-		return []string{"none", "session", "window", "pane"}
+		return []string{"none", "session", "window", "pane", "message"}
 	}
 	return []string{}
 }

--- a/internal/tui/service/command_service_test.go
+++ b/internal/tui/service/command_service_test.go
@@ -380,6 +380,7 @@ func TestGroupByCommandHandler(t *testing.T) {
 	assert.Contains(t, suggestions, "session")
 	assert.Contains(t, suggestions, "window")
 	assert.Contains(t, suggestions, "pane")
+	assert.Contains(t, suggestions, "message")
 }
 
 func TestExpandLevelCommandHandler(t *testing.T) {

--- a/internal/tui/service/help_provider.go
+++ b/internal/tui/service/help_provider.go
@@ -105,13 +105,13 @@ func (p *DefaultHelpProvider) registerGroupByHelp() {
 	p.commands["group-by"] = &model.CommandHelp{
 		Name:        "group-by",
 		Description: "Set the grouping mode for notifications",
-		Usage:       "group-by <none|session|window|pane>",
+		Usage:       "group-by <none|session|window|pane|message>",
 		Arguments: []model.ArgumentHelp{
 			{
 				Name:        "mode",
 				Description: "Grouping mode",
 				Required:    true,
-				Options:     []string{"none", "session", "window", "pane"},
+				Options:     []string{"none", "session", "window", "pane", "message"},
 			},
 		},
 		Examples: []string{
@@ -119,6 +119,7 @@ func (p *DefaultHelpProvider) registerGroupByHelp() {
 			":group-by session",
 			":group-by window",
 			":group-by pane",
+			":group-by message",
 		},
 	}
 }

--- a/internal/tui/state/model_commands.go
+++ b/internal/tui/state/model_commands.go
@@ -109,13 +109,13 @@ func (m *Model) handleWriteCommand(args []string) tea.Cmd {
 
 func (m *Model) handleGroupByCommand(args []string) tea.Cmd {
 	if len(args) != 1 {
-		m.errorHandler.Warning("Invalid usage: group-by <none|session|window|pane>")
+		m.errorHandler.Warning("Invalid usage: group-by <none|session|window|pane|message>")
 		return errorMsgAfter(errorClearDuration)
 	}
 
 	groupBy := strings.ToLower(args[0])
 	if !settings.IsValidGroupBy(groupBy) {
-		m.errorHandler.Warning(fmt.Sprintf("Invalid group-by value: %s (expected one of: none, session, window, pane)", args[0]))
+		m.errorHandler.Warning(fmt.Sprintf("Invalid group-by value: %s (expected one of: none, session, window, pane, message)", args[0]))
 		return errorMsgAfter(errorClearDuration)
 	}
 


### PR DESCRIPTION
Allow group_by='message' in settings validation and load it on TUI startup.

## Changes
- Added GroupByMessage constant to settings
- Updated settings validation to accept 'message' as valid group_by value
- Updated TUI command handler to support 'message' grouping
- Updated TUI help text to include 'message' option
- Added test case for group_by='message' validation
- Updated documentation with message grouping mode details

## Verification
- Config accepts group_by='message' without validation errors
- TUI startup reads config and sets grouping accordingly
- Defaults remain unchanged when group_by is unset
- All tests pass (go test ./...)
- make lint passes

## Related
- Closes tmux-intray-cm3n.2
- Depends on tmux-intray-cm3n.1: Add message group-by in domain
- Part of epic tmux-intray-cm3n: Issue 223: Group/Dedup Notifications