### PR TITLE
Add TUI read filter configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,15 @@ The `tmux-intray tui` command provides an interactive terminal user interface fo
 - Jump to source panes
 - Notifications sorted by most recent first
 - **Settings persistence**: TUI preferences (column order, sort order, filters, view mode) are automatically saved on exit and restored on startup
+- Footer shows the active read/unread filter; adjust it live with `:filter-read <read|unread|all>` and the preference is saved automatically
 - Settings file location: `~/.config/tmux-intray/settings.json`
+
+**Command Mode Commands:**
+- `:w` – Save settings manually
+- `:group-by <none|session|window|pane|message>` – Change grouping strategy
+- `:expand-level <0|1|2|3>` – Set default tree expansion depth
+- `:toggle-view` – Switch between detailed and grouped layouts
+- `:filter-read <read|unread|all>` – Show only read/unread notifications or all and persist the choice
 
 ### Status Bar Integration
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,3 +8,8 @@
 - All notification data is stored in `$TMUX_INTRAY_STATE_DIR/notifications.db`.
 - Automatic database migration on first run with existing data.
 - Improved data integrity with SQLite transactions.
+
+### TUI filtering
+
+- New `filters.read` setting persists whether the TUI should show read, unread, or all notifications. It is documented in `docs/configuration.md`.
+- Added the `:filter-read <read|unread|all>` command and a footer indicator so you can toggle the filter at runtime; the preference is saved automatically between sessions.

--- a/cmd/tmux-intray/settings_test.go
+++ b/cmd/tmux-intray/settings_test.go
@@ -142,6 +142,7 @@ func TestSettingsDefaults(t *testing.T) {
 	// Verify default filters are empty
 	require.Equal(t, "", defaults.Filters.Level)
 	require.Equal(t, "", defaults.Filters.State)
+	require.Equal(t, "", defaults.Filters.Read)
 	require.Equal(t, "", defaults.Filters.Session)
 	require.Equal(t, "", defaults.Filters.Window)
 	require.Equal(t, "", defaults.Filters.Pane)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -153,6 +153,7 @@ sortOrder = "desc"
 [filters]
 level = ""
 state = ""
+read = ""
 session = ""
 window = ""
 pane = ""
@@ -183,6 +184,7 @@ critical = "\u001b[0;31m"
 | `sortOrder` | string | Sort direction | `"desc"` | `"asc"`, `"desc"` |
 | `filters.level` | string | Filter by severity level | `""` (no filter) | `"info"`, `"warning"`, `"error"`, `"critical"`, `""` |
 | `filters.state` | string | Filter by state | `""` (no filter) | `"active"`, `"dismissed"`, `""` |
+| `filters.read` | string | Filter by read/unread status | `""` (all notifications) | `"read"`, `"unread"`, `""` |
 | `filters.session` | string | Filter by tmux session | `""` (no filter) | Session name or `""` |
 | `filters.window` | string | Filter by tmux window | `""` (no filter) | Window ID or `""` |
 | `filters.pane` | string | Filter by tmux pane | `""` (no filter) | Pane ID or `""` |
@@ -194,6 +196,8 @@ critical = "\u001b[0;31m"
 | `groupHeader.showLevelBadges` | bool | Show per-level counts as badges | `true` | `true`, `false` |
 | `groupHeader.showSourceAggregation` | bool | Show aggregated pane/source info | `false` | `true`, `false` |
 | `groupHeader.badgeColors` | table | ANSI color codes per level (`info`, `warning`, `error`, `critical`) | defaults shown above | Strings containing ANSI escape sequences |
+
+`filters.read` lets you persist whether the TUI should show only read, only unread, or all notifications. At runtime you can toggle the same preference with the `:filter-read <read|unread|all>` command; the change is saved back to `settings.toml` automatically.
 
 `groupBy` controls the depth of grouped view hierarchy:
 
@@ -215,6 +219,7 @@ sortOrder = "desc"
 [filters]
 level = ""
 state = ""
+read = ""
 session = ""
 window = ""
 pane = ""
@@ -294,6 +299,7 @@ sortOrder = "asc"
 [filters]
 level = "error"
 state = "active"
+read = "unread"
 session = ""
 window = ""
 pane = ""
@@ -314,6 +320,7 @@ sortOrder = "desc"
 [filters]
 level = "critical"
 state = ""
+read = ""
 session = "work"
 window = ""
 pane = ""
@@ -356,5 +363,6 @@ This ensures that a corrupted settings file doesn't prevent the TUI from running
 - The settings directory (`~/.config/tmux-intray`) is created automatically if it doesn't exist
 - File locking is used to prevent concurrent writes when multiple TUI instances are running
 - Empty string values for filters mean "no filter" (show all)
+- Use the `:filter-read <read|unread|all>` TUI command to change `filters.read` on the fly without editing the file
 - Empty or missing `columns` array uses the default column order
 - For XDG Base Directory compliance, the file location is `$XDG_CONFIG_HOME/tmux-intray/settings.toml`

--- a/internal/settings/manager.go
+++ b/internal/settings/manager.go
@@ -86,6 +86,7 @@ func (t TUIState) IsEmpty() bool {
 		len(t.ExpansionState) == 0 &&
 		t.Filters.Level == "" &&
 		t.Filters.State == "" &&
+		t.Filters.Read == "" &&
 		t.Filters.Session == "" &&
 		t.Filters.Window == "" &&
 		t.Filters.Pane == ""

--- a/internal/settings/manager_test.go
+++ b/internal/settings/manager_test.go
@@ -42,6 +42,7 @@ func TestFromSettings(t *testing.T) {
 				Filters: Filter{
 					Level:   LevelFilterWarning,
 					State:   StateFilterActive,
+					Read:    ReadFilterUnread,
 					Session: "my-session",
 					Window:  "@1",
 					Pane:    "%1",
@@ -60,6 +61,7 @@ func TestFromSettings(t *testing.T) {
 				Filters: Filter{
 					Level:   LevelFilterWarning,
 					State:   StateFilterActive,
+					Read:    ReadFilterUnread,
 					Session: "my-session",
 					Window:  "@1",
 					Pane:    "%1",
@@ -140,6 +142,7 @@ func TestToSettings(t *testing.T) {
 				Filters: Filter{
 					Level:   LevelFilterWarning,
 					State:   StateFilterActive,
+					Read:    ReadFilterUnread,
 					Session: "my-session",
 					Window:  "@1",
 					Pane:    "%1",
@@ -159,6 +162,7 @@ func TestToSettings(t *testing.T) {
 				Filters: Filter{
 					Level:   LevelFilterWarning,
 					State:   StateFilterActive,
+					Read:    ReadFilterUnread,
 					Session: "my-session",
 					Window:  "@1",
 					Pane:    "%1",
@@ -264,6 +268,13 @@ func TestIsEmpty(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "has read filter",
+			state: TUIState{
+				Filters: Filter{Read: ReadFilterUnread},
+			},
+			want: false,
+		},
+		{
 			name: "has filter session",
 			state: TUIState{
 				Filters: Filter{Session: "my-session"},
@@ -333,6 +344,7 @@ func TestRoundTripConversion(t *testing.T) {
 				Filters: Filter{
 					Level:   LevelFilterWarning,
 					State:   StateFilterActive,
+					Read:    ReadFilterUnread,
 					Session: "my-session",
 					Window:  "@1",
 					Pane:    "%1",
@@ -381,6 +393,7 @@ func TestPartialTUIStateConversion(t *testing.T) {
 		Filters: Filter{
 			Level:   LevelFilterWarning,
 			State:   StateFilterActive,
+			Read:    ReadFilterUnread,
 			Session: "my-session",
 		},
 		ViewMode:           ViewModeDetailed,
@@ -406,6 +419,7 @@ func TestPartialTUIStateConversion(t *testing.T) {
 	state.Filters.Session = ""
 	state.Filters.Window = "@1"
 	state.Filters.Pane = "%1"
+	state.Filters.Read = ReadFilterRead
 	state.ExpansionState = map[string]bool{}
 
 	// Convert back to Settings
@@ -417,6 +431,7 @@ func TestPartialTUIStateConversion(t *testing.T) {
 	assert.Equal(t, original.SortOrder, result.SortOrder)
 	assert.Equal(t, original.Filters.Level, result.Filters.Level)
 	assert.Equal(t, original.Filters.State, result.Filters.State)
+	assert.Equal(t, ReadFilterRead, result.Filters.Read)
 	assert.Equal(t, "", result.Filters.Session)
 	assert.Equal(t, "@1", result.Filters.Window)
 	assert.Equal(t, "%1", result.Filters.Pane)
@@ -434,6 +449,7 @@ func TestExtractFromModel(t *testing.T) {
 		Filters: Filter{
 			Level:   LevelFilterWarning,
 			State:   StateFilterActive,
+			Read:    ReadFilterUnread,
 			Session: "session-1",
 		},
 		ViewMode: ViewModeDetailed,

--- a/internal/settings/persistence_test.go
+++ b/internal/settings/persistence_test.go
@@ -30,6 +30,7 @@ func TestSettingsJSONRoundTrip(t *testing.T) {
 		Filters: Filter{
 			Level:   LevelFilterWarning,
 			State:   StateFilterActive,
+			Read:    ReadFilterUnread,
 			Session: "session-1",
 			Window:  "@1",
 			Pane:    "%1",

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -104,6 +104,12 @@ const (
 	LevelFilterCritical = "critical"
 )
 
+// Read filter constants.
+const (
+	ReadFilterRead   = "read"
+	ReadFilterUnread = "unread"
+)
+
 // Filter defines active filter criteria for notification display.
 type Filter struct {
 	// Level filters notifications by severity level.
@@ -115,6 +121,11 @@ type Filter struct {
 	// Empty string means no filter (show all states).
 	// Valid values: "active", "dismissed", "".
 	State string
+
+	// Read filters notifications by read status.
+	// Empty string means no filter (show all notifications).
+	// Valid values: "read", "unread", "".
+	Read string
 
 	// Session filters notifications by tmux session name.
 	// Empty string means no filter (show all sessions).
@@ -215,6 +226,7 @@ func (o GroupHeaderOptions) Validate() error {
 //	  "filters": {
 //	    "level": "",
 //	    "state": "",
+//	    "read": "",
 //	    "session": "",
 //	    "window": "",
 //	    "pane": ""
@@ -277,6 +289,7 @@ func DefaultSettings() *Settings {
 		Filters: Filter{
 			Level:   "",
 			State:   "",
+			Read:    "",
 			Session: "",
 			Window:  "",
 			Pane:    "",
@@ -468,16 +481,6 @@ func Reset() (*Settings, error) {
 	defaults := DefaultSettings()
 	colors.Debug("Settings reset to defaults")
 	return defaults, nil
-}
-
-// IsValidGroupBy returns true if groupBy is a supported grouping mode.
-func IsValidGroupBy(groupBy string) bool {
-	switch groupBy {
-	case GroupByNone, GroupBySession, GroupByWindow, GroupByPane, GroupByMessage:
-		return true
-	default:
-		return false
-	}
 }
 
 // getSettingsPath returns the path to the settings.toml file.

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -25,6 +25,7 @@ func TestDefaultSettings(t *testing.T) {
 	// Check filters
 	assert.Equal(t, "", s.Filters.Level)
 	assert.Equal(t, "", s.Filters.State)
+	assert.Equal(t, "", s.Filters.Read)
 	assert.Equal(t, "", s.Filters.Session)
 	assert.Equal(t, "", s.Filters.Window)
 	assert.Equal(t, "", s.Filters.Pane)
@@ -86,6 +87,7 @@ func TestLoadFromExistingFile(t *testing.T) {
 		Filters: Filter{
 			Level:   LevelFilterWarning,
 			State:   StateFilterActive,
+			Read:    ReadFilterUnread,
 			Session: "my-session",
 		},
 		ViewMode:           ViewModeDetailed,
@@ -123,6 +125,7 @@ func TestLoadFromExistingFile(t *testing.T) {
 	assert.Equal(t, SortOrderAsc, settings.SortOrder)
 	assert.Equal(t, LevelFilterWarning, settings.Filters.Level)
 	assert.Equal(t, StateFilterActive, settings.Filters.State)
+	assert.Equal(t, ReadFilterUnread, settings.Filters.Read)
 	assert.Equal(t, "my-session", settings.Filters.Session)
 	assert.Equal(t, ViewModeDetailed, settings.ViewMode)
 	assert.Equal(t, GroupByWindow, settings.GroupBy)
@@ -394,6 +397,7 @@ func TestValidateValidSettings(t *testing.T) {
 				Filters: Filter{
 					Level:   LevelFilterWarning,
 					State:   StateFilterActive,
+					Read:    ReadFilterUnread,
 					Session: "session1",
 					Window:  "@1",
 					Pane:    "%1",
@@ -493,6 +497,13 @@ func TestValidateInvalidSettings(t *testing.T) {
 				Filters: Filter{State: "invalid"},
 			},
 			wantErr: "invalid filter state",
+		},
+		{
+			name: "invalid read filter",
+			settings: &Settings{
+				Filters: Filter{Read: "invalid"},
+			},
+			wantErr: "invalid filter read value",
 		},
 		{
 			name: "invalid groupBy",

--- a/internal/settings/validation.go
+++ b/internal/settings/validation.go
@@ -124,7 +124,24 @@ func validateFilters(filter Filter) error {
 		return fmt.Errorf("invalid filter state: %s", filter.State)
 	}
 
+	validReadFilters := map[string]bool{
+		"": true, ReadFilterRead: true, ReadFilterUnread: true,
+	}
+	if !validReadFilters[filter.Read] {
+		return fmt.Errorf("invalid filter read value: %s", filter.Read)
+	}
+
 	return nil
+}
+
+// IsValidGroupBy returns true if groupBy is a supported grouping mode.
+func IsValidGroupBy(groupBy string) bool {
+	switch groupBy {
+	case GroupByNone, GroupBySession, GroupByWindow, GroupByPane, GroupByMessage:
+		return true
+	default:
+		return false
+	}
 }
 
 // validate is an alias for Validate for internal use.

--- a/internal/tui/model/notification_service.go
+++ b/internal/tui/model/notification_service.go
@@ -19,7 +19,7 @@ type NotificationService interface {
 	GetFilteredNotifications() []notification.Notification
 
 	// ApplyFiltersAndSearch applies filters/search/sorting and stores filtered results.
-	ApplyFiltersAndSearch(query, state, level, sessionID, windowID, paneID, sortBy, sortOrder string)
+	ApplyFiltersAndSearch(query, state, level, sessionID, windowID, paneID, readFilter, sortBy, sortOrder string)
 
 	// FilterNotifications filters notifications based on a search query.
 	// Returns a list of matching notifications.
@@ -39,6 +39,9 @@ type NotificationService interface {
 
 	// FilterByPane filters notifications by pane ID.
 	FilterByPane(notifications []notification.Notification, paneID string) []notification.Notification
+
+	// FilterByReadStatus filters notifications by read/unread status.
+	FilterByReadStatus(notifications []notification.Notification, readFilter string) []notification.Notification
 
 	// SortNotifications sorts notifications by the specified field and order.
 	SortNotifications(notifications []notification.Notification, sortBy, sortOrder string) []notification.Notification

--- a/internal/tui/model/ui_state.go
+++ b/internal/tui/model/ui_state.go
@@ -186,6 +186,9 @@ type Filters struct {
 	// State filters by notification state (active, dismissed).
 	State string
 
+	// Read filters by read/unread status.
+	Read string
+
 	// Session filters by session ID.
 	Session string
 

--- a/internal/tui/render/render.go
+++ b/internal/tui/render/render.go
@@ -24,7 +24,7 @@ const (
 	groupIndentSize      = 2
 	groupCollapsedSymbol = "▸"
 	groupExpandedSymbol  = "▾"
-	commandList          = "q,w,toggle-view,group-by,expand-level,auto-expand-unread"
+	commandList          = "q,w,toggle-view,group-by,expand-level,filter-read,auto-expand-unread"
 )
 
 // FooterState defines the inputs needed to render footer help text.
@@ -37,6 +37,7 @@ type FooterState struct {
 	ViewMode     string
 	Width        int
 	ErrorMessage string
+	ReadFilter   string
 }
 
 // RowState defines the inputs needed to render a notification row.
@@ -142,6 +143,7 @@ func Footer(state FooterState) string {
 		help = append(help, errorStyle.Render("Error: "+state.ErrorMessage))
 	}
 	help = append(help, fmt.Sprintf("mode: %s", viewModeIndicator(state.ViewMode)))
+	help = append(help, fmt.Sprintf("read: %s", readFilterIndicator(state.ReadFilter)))
 	help = append(help, "j/k: move")
 	help = append(help, "gg/G: top/bottom")
 	if state.SearchMode {
@@ -200,6 +202,17 @@ func viewModeIndicator(mode string) string {
 		return "[G]"
 	default:
 		return "[?]"
+	}
+}
+
+func readFilterIndicator(filter string) string {
+	switch filter {
+	case settings.ReadFilterRead:
+		return "read"
+	case settings.ReadFilterUnread:
+		return "unread"
+	default:
+		return "all"
 	}
 }
 

--- a/internal/tui/render/render_test.go
+++ b/internal/tui/render/render_test.go
@@ -238,6 +238,7 @@ func TestFooterGroupedHelpText(t *testing.T) {
 	footer := Footer(FooterState{Grouped: true, ViewMode: settings.ViewModeGrouped})
 
 	assert.Contains(t, footer, "mode: [G]")
+	assert.Contains(t, footer, "read: all")
 	assert.Contains(t, footer, "v: cycle view mode")
 	assert.Contains(t, footer, "gg/G: top/bottom")
 	assert.Contains(t, footer, "h/l: collapse/expand")
@@ -252,6 +253,14 @@ func TestFooterCommandModeHelpText(t *testing.T) {
 	assert.Contains(t, footer, "cmds: "+commandList)
 	assert.Contains(t, footer, ":group-by window")
 	assert.Contains(t, footer, "Enter: execute")
+}
+
+func TestFooterReadFilterIndicator(t *testing.T) {
+	footer := Footer(FooterState{ViewMode: settings.ViewModeGrouped, ReadFilter: settings.ReadFilterUnread})
+	assert.Contains(t, footer, "read: unread")
+
+	footer = Footer(FooterState{ViewMode: settings.ViewModeGrouped, ReadFilter: settings.ReadFilterRead})
+	assert.Contains(t, footer, "read: read")
 }
 
 func TestFooterClampsToWidthAndClearsLine(t *testing.T) {

--- a/internal/tui/service/help_provider.go
+++ b/internal/tui/service/help_provider.go
@@ -76,6 +76,7 @@ func (p *DefaultHelpProvider) registerDefaultHelp() {
 	p.registerGroupByHelp()
 	p.registerExpandLevelHelp()
 	p.registerToggleViewHelp()
+	p.registerFilterReadHelp()
 }
 
 // registerQuitHelp registers help for the quit command.
@@ -155,5 +156,26 @@ func (p *DefaultHelpProvider) registerToggleViewHelp() {
 		Usage:       "toggle-view",
 		Arguments:   []model.ArgumentHelp{},
 		Examples:    []string{":toggle-view"},
+	}
+}
+
+// registerFilterReadHelp registers help for the filter-read command.
+func (p *DefaultHelpProvider) registerFilterReadHelp() {
+	p.commands["filter-read"] = &model.CommandHelp{
+		Name:        "filter-read",
+		Description: "Filter notifications by read/unread status",
+		Usage:       "filter-read <read|unread|all>",
+		Arguments: []model.ArgumentHelp{
+			{
+				Name:        "status",
+				Description: "Read status to display",
+				Required:    true,
+				Options:     []string{"read", "unread", "all"},
+			},
+		},
+		Examples: []string{
+			":filter-read unread",
+			":filter-read all",
+		},
 	}
 }

--- a/internal/tui/service/help_provider_test.go
+++ b/internal/tui/service/help_provider_test.go
@@ -36,6 +36,11 @@ func TestGetHelp(t *testing.T) {
 	assert.Contains(t, help, "toggle-view")
 	assert.Contains(t, help, "view modes")
 
+	help = provider.GetHelp("filter-read")
+	assert.NotEmpty(t, help)
+	assert.Contains(t, help, "filter-read")
+	assert.Contains(t, help, "read/unread")
+
 	// Test invalid command
 	help = provider.GetHelp("nonexistent")
 	assert.Empty(t, help)
@@ -45,7 +50,7 @@ func TestGetAllHelp(t *testing.T) {
 	provider := NewDefaultHelpProvider()
 
 	helps := provider.GetAllHelp()
-	assert.Len(t, helps, 5) // q, w, group-by, expand-level, toggle-view
+	assert.Len(t, helps, 6) // q, w, group-by, expand-level, toggle-view, filter-read
 
 	// Check for each command
 	commandNames := make([]string, len(helps))
@@ -58,6 +63,7 @@ func TestGetAllHelp(t *testing.T) {
 	assert.Contains(t, commandNames, "group-by")
 	assert.Contains(t, commandNames, "expand-level")
 	assert.Contains(t, commandNames, "toggle-view")
+	assert.Contains(t, commandNames, "filter-read")
 
 	// Check that each help has the expected fields
 	for _, help := range helps {

--- a/internal/tui/service/model_interface.go
+++ b/internal/tui/service/model_interface.go
@@ -35,4 +35,10 @@ type ModelInterface interface {
 
 	// GetViewMode returns the current view mode.
 	GetViewMode() string
+
+	// GetReadFilter returns the current read filter value.
+	GetReadFilter() string
+
+	// SetReadFilter updates the read filter value.
+	SetReadFilter(value string) error
 }

--- a/internal/tui/service/notification_service.go
+++ b/internal/tui/service/notification_service.go
@@ -292,8 +292,18 @@ func (s *DefaultNotificationService) GetFilteredNotifications() []notification.N
 	return s.filtered
 }
 
+// FilterByReadStatus filters notifications by read status.
+func (s *DefaultNotificationService) FilterByReadStatus(notifications []notification.Notification, readFilter string) []notification.Notification {
+	if readFilter == "" {
+		return notifications
+	}
+	domainNotifs := s.convertToDomain(notifications)
+	filtered := domain.FilterByReadStatus(domainNotifs, readFilter)
+	return s.convertFromDomain(filtered)
+}
+
 // ApplyFiltersAndSearch applies filters/search/sorting and stores filtered results.
-func (s *DefaultNotificationService) ApplyFiltersAndSearch(query, state, level, sessionID, windowID, paneID, sortBy, sortOrder string) {
+func (s *DefaultNotificationService) ApplyFiltersAndSearch(query, state, level, sessionID, windowID, paneID, readFilter, sortBy, sortOrder string) {
 	result := s.notifications
 	// Apply state filter
 	if state != "" {
@@ -314,6 +324,10 @@ func (s *DefaultNotificationService) ApplyFiltersAndSearch(query, state, level, 
 	// Apply pane filter
 	if paneID != "" {
 		result = s.FilterByPane(result, paneID)
+	}
+	// Apply read filter
+	if readFilter != "" {
+		result = s.FilterByReadStatus(result, readFilter)
 	}
 	// Apply search query filter
 	if query != "" {

--- a/internal/tui/service/notification_service_test.go
+++ b/internal/tui/service/notification_service_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/cristianoliveira/tmux-intray/internal/notification"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSortNotificationsUnreadFirst(t *testing.T) {
@@ -35,4 +36,34 @@ func TestSortNotificationsUnreadFirstKeepsSortOrderWithinBuckets(t *testing.T) {
 	sorted := svc.SortNotifications(notifications, "id", "asc")
 
 	assert.Equal(t, []int{10, 11, 12, 13}, []int{sorted[0].ID, sorted[1].ID, sorted[2].ID, sorted[3].ID})
+}
+
+func TestFilterByReadStatus(t *testing.T) {
+	svc := NewNotificationService(nil, nil)
+	notifications := []notification.Notification{
+		{ID: 1, Message: "one", Timestamp: "2024-01-01T09:00:00Z", State: "active", Level: "info", ReadTimestamp: ""},
+		{ID: 2, Message: "two", Timestamp: "2024-01-01T10:00:00Z", State: "active", Level: "info", ReadTimestamp: "2024-01-01T10:05:00Z"},
+	}
+
+	unread := svc.FilterByReadStatus(notifications, "unread")
+	require.Len(t, unread, 1)
+	assert.Equal(t, 1, unread[0].ID)
+
+	read := svc.FilterByReadStatus(notifications, "read")
+	require.Len(t, read, 1)
+	assert.Equal(t, 2, read[0].ID)
+}
+
+func TestApplyFiltersAndSearchRespectsReadFilter(t *testing.T) {
+	svc := NewNotificationService(nil, nil)
+	notifications := []notification.Notification{
+		{ID: 1, Message: "alpha", Timestamp: "2024-01-01T09:00:00Z", State: "active", Level: "info", ReadTimestamp: ""},
+		{ID: 2, Message: "beta", Timestamp: "2024-01-01T10:00:00Z", State: "active", Level: "info", ReadTimestamp: "2024-01-01T10:05:00Z"},
+	}
+
+	svc.SetNotifications(notifications)
+	svc.ApplyFiltersAndSearch("", "", "", "", "", "", "unread", "timestamp", "asc")
+	filtered := svc.GetFilteredNotifications()
+	require.Len(t, filtered, 1)
+	assert.Equal(t, 1, filtered[0].ID)
 }

--- a/internal/tui/state/model_bench_test.go
+++ b/internal/tui/state/model_bench_test.go
@@ -548,7 +548,24 @@ func (d *dummyNotificationService) GetFilteredNotifications() []notification.Not
 	return d.filtered
 }
 
-func (d *dummyNotificationService) ApplyFiltersAndSearch(query, state, level, sessionID, windowID, paneID, sortBy, sortOrder string) {
+func (d *dummyNotificationService) FilterByReadStatus(notifications []notification.Notification, readFilter string) []notification.Notification {
+	if readFilter == "" {
+		return notifications
+	}
+	var filtered []notification.Notification
+	for _, n := range notifications {
+		isRead := n.IsRead()
+		if readFilter == settings.ReadFilterUnread && !isRead {
+			filtered = append(filtered, n)
+		}
+		if readFilter == settings.ReadFilterRead && isRead {
+			filtered = append(filtered, n)
+		}
+	}
+	return filtered
+}
+
+func (d *dummyNotificationService) ApplyFiltersAndSearch(query, state, level, sessionID, windowID, paneID, readFilter, sortBy, sortOrder string) {
 	result := d.notifications
 
 	if state != "" {
@@ -569,6 +586,10 @@ func (d *dummyNotificationService) ApplyFiltersAndSearch(query, state, level, se
 
 	if paneID != "" {
 		result = d.FilterByPane(result, paneID)
+	}
+
+	if readFilter != "" {
+		result = d.FilterByReadStatus(result, readFilter)
 	}
 
 	if query != "" {

--- a/internal/tui/state/model_keys.go
+++ b/internal/tui/state/model_keys.go
@@ -3,6 +3,7 @@ package state
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -529,5 +530,23 @@ func (m *Model) SetExpandLevel(level int) error {
 	}
 
 	m.uiState.SetExpandLevel(level)
+	return nil
+}
+
+// GetReadFilter returns the current persisted read filter value.
+func (m *Model) GetReadFilter() string {
+	return m.filters.Read
+}
+
+// SetReadFilter updates the read filter preference.
+func (m *Model) SetReadFilter(value string) error {
+	normalized := strings.ToLower(value)
+	if normalized != "" && normalized != settings.ReadFilterRead && normalized != settings.ReadFilterUnread {
+		return fmt.Errorf("invalid read filter value: %s", value)
+	}
+	if m.filters.Read == normalized {
+		return nil
+	}
+	m.filters.Read = normalized
 	return nil
 }

--- a/internal/tui/state/model_notifications.go
+++ b/internal/tui/state/model_notifications.go
@@ -104,6 +104,7 @@ func (m *Model) applySearchFilter() {
 		m.filters.Session,
 		m.filters.Window,
 		m.filters.Pane,
+		m.filters.Read,
 		m.sortBy,
 		m.sortOrder,
 	)

--- a/internal/tui/state/model_render.go
+++ b/internal/tui/state/model_render.go
@@ -47,6 +47,7 @@ func (m *Model) View() string {
 		ViewMode:     string(m.uiState.GetViewMode()),
 		Width:        m.uiState.GetWidth(),
 		ErrorMessage: m.errorMessage,
+		ReadFilter:   m.filters.Read,
 	}))
 
 	return s.String()

--- a/internal/tui/state/model_test.go
+++ b/internal/tui/state/model_test.go
@@ -2297,6 +2297,7 @@ func TestToState(t *testing.T) {
 				filters: settings.Filter{
 					Level:   settings.LevelFilterWarning,
 					State:   settings.StateFilterActive,
+					Read:    settings.ReadFilterUnread,
 					Session: "my-session",
 					Window:  "@1",
 					Pane:    "%1",
@@ -2309,6 +2310,7 @@ func TestToState(t *testing.T) {
 				Filters: settings.Filter{
 					Level:   settings.LevelFilterWarning,
 					State:   settings.StateFilterActive,
+					Read:    settings.ReadFilterUnread,
 					Session: "my-session",
 					Window:  "@1",
 					Pane:    "%1",
@@ -2405,6 +2407,7 @@ func TestFromState(t *testing.T) {
 				Filters: settings.Filter{
 					Level:   settings.LevelFilterWarning,
 					State:   settings.StateFilterActive,
+					Read:    settings.ReadFilterUnread,
 					Session: "my-session",
 					Window:  "@1",
 					Pane:    "%1",
@@ -2428,6 +2431,7 @@ func TestFromState(t *testing.T) {
 				assert.Equal(t, map[string]bool{"window:@1": true}, m.uiState.GetExpansionState())
 				assert.Equal(t, settings.LevelFilterWarning, m.filters.Level)
 				assert.Equal(t, settings.StateFilterActive, m.filters.State)
+				assert.Equal(t, settings.ReadFilterUnread, m.filters.Read)
 				assert.Equal(t, "my-session", m.filters.Session)
 				assert.Equal(t, "@1", m.filters.Window)
 				assert.Equal(t, "%1", m.filters.Pane)
@@ -2475,6 +2479,7 @@ func TestFromState(t *testing.T) {
 				filters: settings.Filter{
 					Level:   settings.LevelFilterError,
 					State:   settings.StateFilterActive,
+					Read:    settings.ReadFilterUnread,
 					Session: "old-session",
 					Window:  "old-session",
 					Pane:    "old-session",
@@ -2483,6 +2488,7 @@ func TestFromState(t *testing.T) {
 			state: settings.TUIState{
 				Filters: settings.Filter{
 					Level:   settings.LevelFilterWarning,
+					Read:    settings.ReadFilterRead,
 					Session: "new-session",
 				},
 				ExpansionState: map[string]bool{},
@@ -2491,6 +2497,7 @@ func TestFromState(t *testing.T) {
 			verifyFn: func(t *testing.T, m *Model) {
 				assert.Equal(t, settings.LevelFilterWarning, m.filters.Level)
 				assert.Equal(t, settings.StateFilterActive, m.filters.State)
+				assert.Equal(t, settings.ReadFilterRead, m.filters.Read)
 				assert.Equal(t, "new-session", m.filters.Session)
 				// Fields not set in state preserve their old values
 				assert.Equal(t, "old-session", m.filters.Window)
@@ -2532,6 +2539,15 @@ func TestFromState(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSetReadFilter(t *testing.T) {
+	m := &Model{}
+	require.NoError(t, m.SetReadFilter(settings.ReadFilterUnread))
+	assert.Equal(t, settings.ReadFilterUnread, m.GetReadFilter())
+
+	err := m.SetReadFilter("invalid")
+	require.Error(t, err)
 }
 
 func TestModelWithNegativeDimensions(t *testing.T) {

--- a/internal/tui/state/settings_service.go
+++ b/internal/tui/state/settings_service.go
@@ -87,6 +87,9 @@ func applyNonEmptyFilters(src settings.Filter, dest *settings.Filter) {
 	if src.State != "" {
 		dest.State = src.State
 	}
+	if src.Read != "" {
+		dest.Read = src.Read
+	}
 	if src.Session != "" {
 		dest.Session = src.Session
 	}


### PR DESCRIPTION
## Summary
- persist filters.read setting and validation with docs/tests
- route read filter through TUI filtering pipeline and remove config-less command
- split settings validation helpers into separate file to satisfy line limits

## Testing
- make all