### PR TITLE
Enhance TUI group headers

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -161,6 +161,17 @@ viewMode = "grouped"
 groupBy = "none"
 defaultExpandLevel = 1
 expansionState = {}
+
+[groupHeader]
+showTimeRange = true
+showLevelBadges = true
+showSourceAggregation = false
+
+[groupHeader.badgeColors]
+info = "\u001b[0;34m"
+warning = "\u001b[1;33m"
+error = "\u001b[0;31m"
+critical = "\u001b[0;31m"
 ```
 
 #### Settings Fields
@@ -179,6 +190,10 @@ expansionState = {}
 | `groupBy` | string | Group notifications in the TUI | `"none"` | `"none"`, `"session"`, `"window"`, `"pane"`, `"message"` |
 | `defaultExpandLevel` | number | Default grouping expansion depth | `1` | `0`-`3` |
 | `expansionState` | object | Explicit expansion overrides by node path | `{}` | Object of string to boolean |
+| `groupHeader.showTimeRange` | bool | Show earliest/latest ages in group headers | `true` | `true`, `false` |
+| `groupHeader.showLevelBadges` | bool | Show per-level counts as badges | `true` | `true`, `false` |
+| `groupHeader.showSourceAggregation` | bool | Show aggregated pane/source info | `false` | `true`, `false` |
+| `groupHeader.badgeColors` | table | ANSI color codes per level (`info`, `warning`, `error`, `critical`) | defaults shown above | Strings containing ANSI escape sequences |
 
 `groupBy` controls the depth of grouped view hierarchy:
 
@@ -208,6 +223,17 @@ viewMode = "grouped"
 groupBy = "none"
 defaultExpandLevel = 1
 expansionState = {}
+
+[groupHeader]
+showTimeRange = true
+showLevelBadges = true
+showSourceAggregation = false
+
+[groupHeader.badgeColors]
+info = "\u001b[0;34m"
+warning = "\u001b[1;33m"
+error = "\u001b[0;31m"
+critical = "\u001b[0;31m"
 ```
 
 ### How Settings Are Saved
@@ -298,6 +324,21 @@ defaultExpandLevel = 2
 
 [expansionState]
 "session:work" = true
+
+**Customize group headers:**
+
+```toml
+[groupHeader]
+showTimeRange = false
+showLevelBadges = false
+showSourceAggregation = true
+
+[groupHeader.badgeColors]
+info = "\u001b[0;36m"
+warning = "\u001b[1;33m"
+error = "\u001b[0;31m"
+critical = "\u001b[0;31m"
+```
 ```
 
 ### Error Handling

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -129,6 +129,81 @@ type Filter struct {
 	Pane string
 }
 
+// GroupHeaderOptions controls how group headers render additional context.
+type GroupHeaderOptions struct {
+	// ShowTimeRange toggles whether grouped nodes display earliest/latest ages.
+	ShowTimeRange bool `toml:"showTimeRange"`
+
+	// ShowLevelBadges toggles whether grouped nodes display level badges.
+	ShowLevelBadges bool `toml:"showLevelBadges"`
+
+	// ShowSourceAggregation toggles whether grouped nodes display source info.
+	ShowSourceAggregation bool `toml:"showSourceAggregation"`
+
+	// BadgeColors defines ANSI color codes per level key.
+	// Keys: info, warning, error, critical.
+	BadgeColors map[string]string `toml:"badgeColors"`
+}
+
+// DefaultGroupHeaderOptions returns default rendering options for group headers.
+func DefaultGroupHeaderOptions() GroupHeaderOptions {
+	return GroupHeaderOptions{
+		ShowTimeRange:         true,
+		ShowLevelBadges:       true,
+		ShowSourceAggregation: false,
+		BadgeColors:           defaultBadgeColors(),
+	}
+}
+
+// Clone returns a copy of the options with a deep copy of BadgeColors.
+func (o GroupHeaderOptions) Clone() GroupHeaderOptions {
+	clone := GroupHeaderOptions{
+		ShowTimeRange:         o.ShowTimeRange,
+		ShowLevelBadges:       o.ShowLevelBadges,
+		ShowSourceAggregation: o.ShowSourceAggregation,
+		BadgeColors:           make(map[string]string, len(o.BadgeColors)),
+	}
+	for level, color := range o.BadgeColors {
+		clone.BadgeColors[level] = color
+	}
+	clone.normalize()
+	return clone
+}
+
+func defaultBadgeColors() map[string]string {
+	return map[string]string{
+		LevelFilterInfo:     colors.Blue,
+		LevelFilterWarning:  colors.Yellow,
+		LevelFilterError:    colors.Red,
+		LevelFilterCritical: colors.Red,
+	}
+}
+
+func (o *GroupHeaderOptions) normalize() {
+	if o == nil {
+		return
+	}
+	if o.BadgeColors == nil {
+		o.BadgeColors = make(map[string]string)
+	}
+	for level, color := range defaultBadgeColors() {
+		if o.BadgeColors[level] == "" {
+			o.BadgeColors[level] = color
+		}
+	}
+}
+
+// Validate ensures the options structure is well-formed.
+func (o GroupHeaderOptions) Validate() error {
+	requiredLevels := []string{LevelFilterInfo, LevelFilterWarning, LevelFilterError, LevelFilterCritical}
+	for _, level := range requiredLevels {
+		if o.BadgeColors[level] == "" {
+			return fmt.Errorf("missing badge color for level: %s", level)
+		}
+	}
+	return nil
+}
+
 // Settings holds TUI user preferences persisted to disk.
 //
 // TOML Schema:
@@ -188,6 +263,9 @@ type Settings struct {
 
 	// ExpansionState stores explicit expansion overrides by node path.
 	ExpansionState map[string]bool
+
+	// GroupHeader configures group header rendering.
+	GroupHeader GroupHeaderOptions `toml:"groupHeader"`
 }
 
 // DefaultSettings returns settings with all default values.
@@ -208,6 +286,7 @@ func DefaultSettings() *Settings {
 		DefaultExpandLevel: 1,
 		AutoExpandUnread:   false, // Default to false to avoid unexpected behavior
 		ExpansionState:     map[string]bool{},
+		GroupHeader:        DefaultGroupHeaderOptions(),
 	}
 }
 
@@ -391,71 +470,6 @@ func Reset() (*Settings, error) {
 	return defaults, nil
 }
 
-// Validate checks that settings values are valid.
-// Preconditions: settings must be non-nil.
-func Validate(settings *Settings) error {
-	// Validate columns
-	validColumns := map[string]bool{
-		ColumnID: true, ColumnTimestamp: true, ColumnState: true,
-		ColumnSession: true, ColumnWindow: true, ColumnPane: true,
-		ColumnMessage: true, ColumnPaneCreated: true, ColumnLevel: true,
-	}
-	if len(settings.Columns) > 0 {
-		for _, col := range settings.Columns {
-			if !validColumns[col] {
-				return fmt.Errorf("invalid column name: %s", col)
-			}
-		}
-	}
-
-	// Validate sortBy
-	validSortBy := map[string]bool{
-		SortByID: true, SortByTimestamp: true, SortByState: true,
-		SortByLevel: true, SortBySession: true,
-	}
-	if settings.SortBy != "" && !validSortBy[settings.SortBy] {
-		return fmt.Errorf("invalid sortBy value: %s", settings.SortBy)
-	}
-
-	// Validate sortOrder
-	if settings.SortOrder != "" && settings.SortOrder != SortOrderAsc && settings.SortOrder != SortOrderDesc {
-		return fmt.Errorf("invalid sortOrder value: %s", settings.SortOrder)
-	}
-
-	// Validate viewMode
-	if settings.ViewMode != "" && settings.ViewMode != ViewModeCompact && settings.ViewMode != ViewModeDetailed && settings.ViewMode != ViewModeGrouped {
-		return fmt.Errorf("invalid viewMode value: %s", settings.ViewMode)
-	}
-
-	// Validate groupBy
-	if settings.GroupBy != "" && !IsValidGroupBy(settings.GroupBy) {
-		return fmt.Errorf("invalid groupBy value: %s", settings.GroupBy)
-	}
-
-	// Validate defaultExpandLevel
-	if settings.DefaultExpandLevel < MinExpandLevel || settings.DefaultExpandLevel > MaxExpandLevel {
-		return fmt.Errorf("invalid defaultExpandLevel value: %d", settings.DefaultExpandLevel)
-	}
-
-	// Validate filters
-	validLevels := map[string]bool{
-		"": true, LevelFilterInfo: true, LevelFilterWarning: true,
-		LevelFilterError: true, LevelFilterCritical: true,
-	}
-	if !validLevels[settings.Filters.Level] {
-		return fmt.Errorf("invalid filter level: %s", settings.Filters.Level)
-	}
-
-	validStates := map[string]bool{
-		"": true, StateFilterActive: true, StateFilterDismissed: true,
-	}
-	if !validStates[settings.Filters.State] {
-		return fmt.Errorf("invalid filter state: %s", settings.Filters.State)
-	}
-
-	return nil
-}
-
 // IsValidGroupBy returns true if groupBy is a supported grouping mode.
 func IsValidGroupBy(groupBy string) bool {
 	switch groupBy {
@@ -464,11 +478,6 @@ func IsValidGroupBy(groupBy string) bool {
 	default:
 		return false
 	}
-}
-
-// validate is an alias for Validate for internal use.
-func validate(settings *Settings) error {
-	return Validate(settings)
 }
 
 // getSettingsPath returns the path to the settings.toml file.

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/cristianoliveira/tmux-intray/internal/colors"
 	"github.com/cristianoliveira/tmux-intray/internal/config"
 	"github.com/pelletier/go-toml/v2"
 	"github.com/stretchr/testify/assert"
@@ -35,6 +36,15 @@ func TestDefaultSettings(t *testing.T) {
 	assert.Equal(t, GroupByNone, s.GroupBy)
 	assert.Equal(t, 1, s.DefaultExpandLevel)
 	assert.Equal(t, map[string]bool{}, s.ExpansionState)
+
+	// Check group header options
+	assert.True(t, s.GroupHeader.ShowTimeRange)
+	assert.True(t, s.GroupHeader.ShowLevelBadges)
+	assert.False(t, s.GroupHeader.ShowSourceAggregation)
+	assert.Equal(t, colors.Blue, s.GroupHeader.BadgeColors[LevelFilterInfo])
+	assert.Equal(t, colors.Yellow, s.GroupHeader.BadgeColors[LevelFilterWarning])
+	assert.Equal(t, colors.Red, s.GroupHeader.BadgeColors[LevelFilterError])
+	assert.Equal(t, colors.Red, s.GroupHeader.BadgeColors[LevelFilterCritical])
 }
 
 func TestLoadDefaultWhenFileDoesNotExist(t *testing.T) {
@@ -56,6 +66,7 @@ func TestLoadDefaultWhenFileDoesNotExist(t *testing.T) {
 	assert.Equal(t, expected.GroupBy, settings.GroupBy)
 	assert.Equal(t, expected.DefaultExpandLevel, settings.DefaultExpandLevel)
 	assert.Equal(t, expected.ExpansionState, settings.ExpansionState)
+	assert.Equal(t, expected.GroupHeader, settings.GroupHeader)
 }
 
 func TestLoadFromExistingFile(t *testing.T) {
@@ -83,6 +94,17 @@ func TestLoadFromExistingFile(t *testing.T) {
 		ExpansionState: map[string]bool{
 			"window:@1": true,
 		},
+		GroupHeader: GroupHeaderOptions{
+			ShowTimeRange:         false,
+			ShowLevelBadges:       true,
+			ShowSourceAggregation: true,
+			BadgeColors: map[string]string{
+				LevelFilterInfo:     colors.Green,
+				LevelFilterWarning:  colors.Yellow,
+				LevelFilterError:    colors.Red,
+				LevelFilterCritical: colors.Red,
+			},
+		},
 	}
 
 	data, err := toml.Marshal(customSettings)
@@ -106,6 +128,7 @@ func TestLoadFromExistingFile(t *testing.T) {
 	assert.Equal(t, GroupByWindow, settings.GroupBy)
 	assert.Equal(t, 2, settings.DefaultExpandLevel)
 	assert.Equal(t, map[string]bool{"window:@1": true}, settings.ExpansionState)
+	assert.Equal(t, customSettings.GroupHeader, settings.GroupHeader)
 }
 
 func TestLoadPartialSettings(t *testing.T) {
@@ -140,6 +163,7 @@ viewMode = "detailed"
 	assert.Equal(t, GroupByNone, settings.GroupBy)
 	assert.Equal(t, 1, settings.DefaultExpandLevel)
 	assert.Equal(t, map[string]bool{}, settings.ExpansionState)
+	assert.Equal(t, DefaultSettings().GroupHeader, settings.GroupHeader)
 }
 
 func TestLoadInvalidTOML(t *testing.T) {
@@ -242,6 +266,17 @@ func TestSave(t *testing.T) {
 		ExpansionState: map[string]bool{
 			"session:$1": true,
 		},
+		GroupHeader: GroupHeaderOptions{
+			ShowTimeRange:         true,
+			ShowLevelBadges:       false,
+			ShowSourceAggregation: false,
+			BadgeColors: map[string]string{
+				LevelFilterInfo:     colors.Blue,
+				LevelFilterWarning:  colors.Yellow,
+				LevelFilterError:    colors.Red,
+				LevelFilterCritical: colors.Red,
+			},
+		},
 	}
 
 	// Save settings
@@ -269,6 +304,7 @@ func TestSave(t *testing.T) {
 	assert.Equal(t, settings.GroupBy, loaded.GroupBy)
 	assert.Equal(t, settings.DefaultExpandLevel, loaded.DefaultExpandLevel)
 	assert.Equal(t, settings.ExpansionState, loaded.ExpansionState)
+	assert.Equal(t, settings.GroupHeader, loaded.GroupHeader)
 }
 
 func TestSaveInvalidSettings(t *testing.T) {

--- a/internal/settings/validate.go
+++ b/internal/settings/validate.go
@@ -1,0 +1,133 @@
+package settings
+
+import "fmt"
+
+// Validate checks that settings values are valid.
+// Preconditions: settings must be non-nil.
+func Validate(settings *Settings) error {
+	if settings == nil {
+		return fmt.Errorf("settings cannot be nil")
+	}
+
+	settings.GroupHeader.normalize()
+	if err := settings.GroupHeader.Validate(); err != nil {
+		return fmt.Errorf("invalid groupHeader options: %w", err)
+	}
+	if err := validateColumns(settings.Columns); err != nil {
+		return err
+	}
+	if err := validateSortBy(settings.SortBy); err != nil {
+		return err
+	}
+	if err := validateSortOrder(settings.SortOrder); err != nil {
+		return err
+	}
+	if err := validateViewMode(settings.ViewMode); err != nil {
+		return err
+	}
+	if err := validateGroupBySetting(settings.GroupBy); err != nil {
+		return err
+	}
+	if err := validateExpandLevel(settings.DefaultExpandLevel); err != nil {
+		return err
+	}
+	if err := validateFilters(settings.Filters); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateColumns(columns []string) error {
+	if len(columns) == 0 {
+		return nil
+	}
+	validColumns := map[string]bool{
+		ColumnID: true, ColumnTimestamp: true, ColumnState: true,
+		ColumnSession: true, ColumnWindow: true, ColumnPane: true,
+		ColumnMessage: true, ColumnPaneCreated: true, ColumnLevel: true,
+	}
+	for _, col := range columns {
+		if !validColumns[col] {
+			return fmt.Errorf("invalid column name: %s", col)
+		}
+	}
+	return nil
+}
+
+func validateSortBy(sortBy string) error {
+	if sortBy == "" {
+		return nil
+	}
+	validSortBy := map[string]bool{
+		SortByID: true, SortByTimestamp: true, SortByState: true,
+		SortByLevel: true, SortBySession: true,
+	}
+	if !validSortBy[sortBy] {
+		return fmt.Errorf("invalid sortBy value: %s", sortBy)
+	}
+	return nil
+}
+
+func validateSortOrder(order string) error {
+	if order == "" {
+		return nil
+	}
+	if order != SortOrderAsc && order != SortOrderDesc {
+		return fmt.Errorf("invalid sortOrder value: %s", order)
+	}
+	return nil
+}
+
+func validateViewMode(mode string) error {
+	if mode == "" {
+		return nil
+	}
+	switch mode {
+	case ViewModeCompact, ViewModeDetailed, ViewModeGrouped:
+		return nil
+	default:
+		return fmt.Errorf("invalid viewMode value: %s", mode)
+	}
+}
+
+func validateGroupBySetting(groupBy string) error {
+	if groupBy == "" {
+		return nil
+	}
+	if !IsValidGroupBy(groupBy) {
+		return fmt.Errorf("invalid groupBy value: %s", groupBy)
+	}
+	return nil
+}
+
+func validateExpandLevel(level int) error {
+	if level < MinExpandLevel || level > MaxExpandLevel {
+		return fmt.Errorf("invalid defaultExpandLevel value: %d", level)
+	}
+	return nil
+}
+
+func validateFilters(filter Filter) error {
+	validLevels := map[string]bool{
+		"": true, LevelFilterInfo: true, LevelFilterWarning: true,
+		LevelFilterError: true, LevelFilterCritical: true,
+	}
+	if !validLevels[filter.Level] {
+		return fmt.Errorf("invalid filter level: %s", filter.Level)
+	}
+
+	validStates := map[string]bool{
+		"": true, StateFilterActive: true, StateFilterDismissed: true,
+	}
+	if !validStates[filter.State] {
+		return fmt.Errorf("invalid filter state: %s", filter.State)
+	}
+
+	return nil
+}
+
+// validate is an alias for Validate for internal use.
+func validate(settings *Settings) error {
+	return Validate(settings)
+}

--- a/internal/tui/model/tree_service.go
+++ b/internal/tui/model/tree_service.go
@@ -3,6 +3,8 @@
 package model
 
 import (
+	"fmt"
+
 	"github.com/cristianoliveira/tmux-intray/internal/notification"
 )
 
@@ -95,6 +97,27 @@ type TreeNode struct {
 
 	// LatestEvent is the most recent notification under this group node.
 	LatestEvent *notification.Notification
+
+	// EarliestEvent is the oldest notification under this group node.
+	EarliestEvent *notification.Notification
+
+	// LevelCounts tracks counts per notification level.
+	LevelCounts map[string]int
+
+	// Sources contains unique source references contributing to this node.
+	Sources map[string]NotificationSource
+}
+
+// NotificationSource represents a unique tmux context for notifications.
+type NotificationSource struct {
+	Session string
+	Window  string
+	Pane    string
+}
+
+// SourceKey returns a stable key for the source.
+func (s NotificationSource) SourceKey() string {
+	return fmt.Sprintf("%s\x00%s\x00%s", s.Session, s.Window, s.Pane)
 }
 
 // NodeKind represents the type of a tree node.

--- a/internal/tui/render/group_row.go
+++ b/internal/tui/render/group_row.go
@@ -1,0 +1,319 @@
+package render
+
+import (
+	"fmt"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/cristianoliveira/tmux-intray/internal/colors"
+	"github.com/cristianoliveira/tmux-intray/internal/settings"
+)
+
+// GroupNode defines the inputs needed to render a grouped tree node.
+type GroupNode struct {
+	Title       string
+	Display     string
+	Expanded    bool
+	Count       int
+	UnreadCount int
+}
+
+// GroupRow defines the inputs needed to render a group row.
+type GroupRow struct {
+	Node     *GroupNode
+	Selected bool
+	Level    int
+	Width    int
+	Styles   *GroupRowStyles
+	Now      time.Time
+	// EarliestTimestamp and LatestTimestamp are RFC3339 times.
+	EarliestTimestamp string
+	LatestTimestamp   string
+	LevelCounts       map[string]int
+	Sources           []string
+	Options           settings.GroupHeaderOptions
+}
+
+// GroupRowStyles defines styles for group rows.
+type GroupRowStyles struct {
+	Base     lipgloss.Style
+	Selected lipgloss.Style
+}
+
+type groupRowSegment struct {
+	text  string
+	style *lipgloss.Style
+}
+
+func (s groupRowSegment) width() int {
+	return utf8.RuneCountInString(s.text)
+}
+
+// RenderGroupRow renders a single group row.
+func RenderGroupRow(row GroupRow) string {
+	if row.Node == nil {
+		return ""
+	}
+
+	styles := ensureGroupRowStyles(row.Styles)
+	options := resolveGroupRowOptions(row.Options)
+
+	segments := buildGroupRowSegments(row, options)
+	segments = clampGroupRowSegments(segments, row.Width)
+	plain := plainTextFromSegments(segments)
+	if row.Selected {
+		return styles.Selected.Render(plain)
+	}
+	return renderSegments(segments, groupBaseStyle(row, styles))
+}
+
+func ensureGroupRowStyles(styles *GroupRowStyles) *GroupRowStyles {
+	if styles != nil {
+		return styles
+	}
+	defaults := defaultGroupRowStyles()
+	return &defaults
+}
+
+func buildGroupRowSegments(row GroupRow, options settings.GroupHeaderOptions) []groupRowSegment {
+	segments := []groupRowSegment{buildGroupTitleSegment(row)}
+	segments = appendTimeRangeSegment(segments, row, options)
+	segments = appendBadgeSegments(segments, row, options)
+	return appendSourceSegment(segments, row.Sources, options)
+}
+
+func buildGroupTitleSegment(row GroupRow) groupRowSegment {
+	indent := strings.Repeat(" ", groupIndentSize*row.Level)
+	symbol := groupCollapsedSymbol
+	if row.Node.Expanded {
+		symbol = groupExpandedSymbol
+	}
+	title := resolveGroupTitle(row.Node)
+	countLabel := formatGroupCount(row.Node.Count, row.Node.UnreadCount)
+	return groupRowSegment{text: fmt.Sprintf("%s%s %s (%s)", indent, symbol, title, countLabel)}
+}
+
+func resolveGroupTitle(node *GroupNode) string {
+	if node == nil {
+		return ""
+	}
+	if node.Display != "" {
+		return node.Display
+	}
+	return node.Title
+}
+
+func formatGroupCount(total, unread int) string {
+	if unread > 0 {
+		return fmt.Sprintf("%d/%d", total, unread)
+	}
+	return fmt.Sprintf("%d", total)
+}
+
+func appendTimeRangeSegment(segments []groupRowSegment, row GroupRow, options settings.GroupHeaderOptions) []groupRowSegment {
+	if timeRange := buildTimeRangeLabel(row, options); timeRange != "" {
+		return appendSegmentWithGap(segments, groupRowSegment{text: timeRange}, "  ")
+	}
+	return segments
+}
+
+func appendBadgeSegments(segments []groupRowSegment, row GroupRow, options settings.GroupHeaderOptions) []groupRowSegment {
+	badges := buildBadgeSegments(row, options)
+	if len(badges) == 0 {
+		return segments
+	}
+	if len(segments) > 0 {
+		segments = append(segments, groupRowSegment{text: "  "})
+	}
+	for idx, badge := range badges {
+		if idx > 0 {
+			segments = append(segments, groupRowSegment{text: " "})
+		}
+		segments = append(segments, badge)
+	}
+	return segments
+}
+
+func appendSourceSegment(segments []groupRowSegment, sources []string, options settings.GroupHeaderOptions) []groupRowSegment {
+	if sourceLabel := buildSourceLabel(sources, options); sourceLabel != "" {
+		return appendSegmentWithGap(segments, groupRowSegment{text: sourceLabel}, "  ")
+	}
+	return segments
+}
+
+func appendSegmentWithGap(segments []groupRowSegment, addition groupRowSegment, gap string) []groupRowSegment {
+	if addition.text == "" {
+		return segments
+	}
+	if gap != "" && len(segments) > 0 {
+		segments = append(segments, groupRowSegment{text: gap})
+	}
+	return append(segments, addition)
+}
+
+func groupBaseStyle(row GroupRow, styles *GroupRowStyles) lipgloss.Style {
+	if row.Node != nil && row.Node.UnreadCount > 0 {
+		unreadStyles := stylesWithUnread()
+		return unreadStyles.Base
+	}
+	return styles.Base
+}
+
+func defaultGroupRowStyles() GroupRowStyles {
+	base := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color(ansiColorNumber(colors.Blue)))
+	selected := lipgloss.NewStyle().
+		Bold(true).
+		Background(lipgloss.Color(ansiColorNumber(colors.Blue))).
+		Foreground(lipgloss.Color("0"))
+	return GroupRowStyles{
+		Base:     base,
+		Selected: selected,
+	}
+}
+
+func stylesWithUnread() GroupRowStyles {
+	base := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color(ansiColorNumber(colors.Yellow)))
+	selected := lipgloss.NewStyle().
+		Bold(true).
+		Background(lipgloss.Color(ansiColorNumber(colors.Blue))).
+		Foreground(lipgloss.Color("0"))
+	return GroupRowStyles{
+		Base:     base,
+		Selected: selected,
+	}
+}
+
+func truncateGroupRow(value string, width int) string {
+	if width <= 0 {
+		return value
+	}
+	if utf8.RuneCountInString(value) <= width {
+		return value
+	}
+	return string([]rune(value)[:width])
+}
+
+func resolveGroupRowOptions(options settings.GroupHeaderOptions) settings.GroupHeaderOptions {
+	if options.BadgeColors == nil && !options.ShowTimeRange && !options.ShowLevelBadges && !options.ShowSourceAggregation {
+		return settings.DefaultGroupHeaderOptions()
+	}
+	return options.Clone()
+}
+
+func buildTimeRangeLabel(row GroupRow, options settings.GroupHeaderOptions) string {
+	if !options.ShowTimeRange {
+		return ""
+	}
+	earliest := calculateAge(row.EarliestTimestamp, row.Now)
+	latest := calculateAge(row.LatestTimestamp, row.Now)
+	if earliest == "" && latest == "" {
+		return ""
+	}
+	if earliest == "" {
+		return latest
+	}
+	if latest == "" || earliest == latest {
+		return earliest
+	}
+	return fmt.Sprintf("%s – %s", earliest, latest)
+}
+
+var severityDisplayOrder = []string{settings.LevelFilterCritical, settings.LevelFilterError, settings.LevelFilterWarning, settings.LevelFilterInfo}
+
+func buildBadgeSegments(row GroupRow, options settings.GroupHeaderOptions) []groupRowSegment {
+	if !options.ShowLevelBadges || len(row.LevelCounts) == 0 {
+		return nil
+	}
+	segments := make([]groupRowSegment, 0, len(row.LevelCounts))
+	for _, level := range severityDisplayOrder {
+		count := row.LevelCounts[level]
+		if count == 0 {
+			continue
+		}
+		style := lipgloss.NewStyle().Bold(true)
+		if color := options.BadgeColors[level]; color != "" {
+			style = style.Foreground(lipgloss.Color(ansiColorNumber(color)))
+		}
+		segments = append(segments, groupRowSegment{
+			text:  fmt.Sprintf("%s%d", badgeIconForLevel(level), count),
+			style: &style,
+		})
+	}
+	return segments
+}
+
+func buildSourceLabel(sources []string, options settings.GroupHeaderOptions) string {
+	if !options.ShowSourceAggregation || len(sources) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("src: %s", strings.Join(sources, ","))
+}
+
+func badgeIconForLevel(level string) string {
+	switch level {
+	case settings.LevelFilterCritical:
+		return "‼"
+	case settings.LevelFilterError:
+		return "❌"
+	case settings.LevelFilterWarning:
+		return "⚠"
+	default:
+		return "ℹ"
+	}
+}
+
+func clampGroupRowSegments(segments []groupRowSegment, width int) []groupRowSegment {
+	if width <= 0 {
+		return segments
+	}
+	remaining := width
+	result := make([]groupRowSegment, 0, len(segments))
+	for _, segment := range segments {
+		segWidth := segment.width()
+		if segWidth == 0 {
+			result = append(result, segment)
+			continue
+		}
+		if remaining <= 0 {
+			break
+		}
+		if segWidth <= remaining {
+			result = append(result, segment)
+			remaining -= segWidth
+			continue
+		}
+		runes := []rune(segment.text)
+		if len(runes) > remaining {
+			runes = runes[:remaining]
+		}
+		result = append(result, groupRowSegment{text: string(runes), style: segment.style})
+		break
+	}
+	return result
+}
+
+func plainTextFromSegments(segments []groupRowSegment) string {
+	var builder strings.Builder
+	for _, segment := range segments {
+		builder.WriteString(segment.text)
+	}
+	return builder.String()
+}
+
+func renderSegments(segments []groupRowSegment, base lipgloss.Style) string {
+	var builder strings.Builder
+	for _, segment := range segments {
+		if segment.style != nil {
+			builder.WriteString(segment.style.Render(segment.text))
+			continue
+		}
+		builder.WriteString(base.Render(segment.text))
+	}
+	return builder.String()
+}

--- a/internal/tui/render/render.go
+++ b/internal/tui/render/render.go
@@ -48,30 +48,6 @@ type RowState struct {
 	Now          time.Time
 }
 
-// GroupNode defines the inputs needed to render a grouped tree node.
-type GroupNode struct {
-	Title       string
-	Display     string
-	Expanded    bool
-	Count       int
-	UnreadCount int
-}
-
-// GroupRow defines the inputs needed to render a group row.
-type GroupRow struct {
-	Node     *GroupNode
-	Selected bool
-	Level    int
-	Width    int
-	Styles   *GroupRowStyles
-}
-
-// GroupRowStyles defines styles for group rows.
-type GroupRowStyles struct {
-	Base     lipgloss.Style
-	Selected lipgloss.Style
-}
-
 // Header renders the table header.
 func Header(width int) string {
 	headerStyle := lipgloss.NewStyle().
@@ -156,53 +132,6 @@ func Row(state RowState) string {
 	return row.String()
 }
 
-// RenderGroupRow renders a single group row.
-func RenderGroupRow(row GroupRow) string {
-	if row.Node == nil {
-		return ""
-	}
-
-	styles := row.Styles
-	if styles == nil {
-		defaultStyles := defaultGroupRowStyles()
-		styles = &defaultStyles
-	}
-
-	indent := strings.Repeat(" ", groupIndentSize*row.Level)
-	symbol := groupCollapsedSymbol
-	if row.Node.Expanded {
-		symbol = groupExpandedSymbol
-	}
-
-	title := row.Node.Display
-	if title == "" {
-		title = row.Node.Title
-	}
-
-	// Format: "title (total/unread)"
-	var countLabel string
-	if row.Node.UnreadCount > 0 {
-		countLabel = fmt.Sprintf("%d/%d", row.Node.Count, row.Node.UnreadCount)
-	} else {
-		countLabel = fmt.Sprintf("%d", row.Node.Count)
-	}
-
-	label := fmt.Sprintf("%s%s %s (%s)", indent, symbol, title, countLabel)
-	label = truncateGroupRow(label, row.Width)
-
-	if row.Selected {
-		return styles.Selected.Render(label)
-	}
-
-	// Use different style for groups with unread items
-	if row.Node.UnreadCount > 0 {
-		styles := stylesWithUnread()
-		return styles.Base.Render(label)
-	}
-
-	return styles.Base.Render(label)
-}
-
 // Footer renders the footer with help text.
 func Footer(state FooterState) string {
 	helpStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
@@ -277,45 +206,6 @@ func viewModeIndicator(mode string) string {
 func calculateMessageWidth(width int) int {
 	totalFixedWidth := readStatusWidth + typeWidth + statusWidth + sessionWidth + paneWidth + ageWidth
 	return width - totalFixedWidth - spacesBetweenColumns
-}
-
-func defaultGroupRowStyles() GroupRowStyles {
-	base := lipgloss.NewStyle().
-		Bold(true).
-		Foreground(lipgloss.Color(ansiColorNumber(colors.Blue)))
-	selected := lipgloss.NewStyle().
-		Bold(true).
-		Background(lipgloss.Color(ansiColorNumber(colors.Blue))).
-		Foreground(lipgloss.Color("0"))
-	return GroupRowStyles{
-		Base:     base,
-		Selected: selected,
-	}
-}
-
-func stylesWithUnread() GroupRowStyles {
-	// Use a different color (e.g., yellow/orange) for groups with unread items
-	base := lipgloss.NewStyle().
-		Bold(true).
-		Foreground(lipgloss.Color(ansiColorNumber(colors.Yellow)))
-	selected := lipgloss.NewStyle().
-		Bold(true).
-		Background(lipgloss.Color(ansiColorNumber(colors.Blue))).
-		Foreground(lipgloss.Color("0"))
-	return GroupRowStyles{
-		Base:     base,
-		Selected: selected,
-	}
-}
-
-func truncateGroupRow(value string, width int) string {
-	if width <= 0 {
-		return value
-	}
-	if utf8.RuneCountInString(value) <= width {
-		return value
-	}
-	return string([]rune(value)[:width])
 }
 
 func levelIcon(level string) string {

--- a/internal/tui/render/render_test.go
+++ b/internal/tui/render/render_test.go
@@ -1,6 +1,7 @@
 package render
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -123,6 +124,7 @@ func TestRenderGroupRowIndentationAndSymbol(t *testing.T) {
 		Base:     lipgloss.NewStyle(),
 		Selected: lipgloss.NewStyle(),
 	}
+	options := disabledGroupHeaderOptions()
 
 	row := RenderGroupRow(GroupRow{
 		Node: &GroupNode{
@@ -131,9 +133,10 @@ func TestRenderGroupRowIndentationAndSymbol(t *testing.T) {
 			Expanded: true,
 			Count:    3,
 		},
-		Level:  1,
-		Width:  80,
-		Styles: &styles,
+		Level:   1,
+		Width:   80,
+		Styles:  &styles,
+		Options: options,
 	})
 
 	assert.True(t, strings.HasPrefix(row, "  ▾ session-one (3)"))
@@ -144,9 +147,10 @@ func TestRenderGroupRowIndentationAndSymbol(t *testing.T) {
 			Expanded: false,
 			Count:    2,
 		},
-		Level:  2,
-		Width:  80,
-		Styles: &styles,
+		Level:   2,
+		Width:   80,
+		Styles:  &styles,
+		Options: options,
 	})
 
 	assert.True(t, strings.HasPrefix(row, "    ▸ win-1 (2)"))
@@ -165,12 +169,69 @@ func TestRenderGroupRowTruncatesToWidth(t *testing.T) {
 			Expanded: true,
 			Count:    12,
 		},
-		Level:  0,
-		Width:  10,
-		Styles: &styles,
+		Level:   0,
+		Width:   10,
+		Styles:  &styles,
+		Options: disabledGroupHeaderOptions(),
 	})
 
 	assert.Equal(t, 10, utf8.RuneCountInString(row))
+}
+
+func TestRenderGroupRowDisplaysTimeRange(t *testing.T) {
+	styles := GroupRowStyles{Base: lipgloss.NewStyle(), Selected: lipgloss.NewStyle()}
+	fixedNow := time.Date(2025, 1, 2, 12, 0, 0, 0, time.UTC)
+	row := RenderGroupRow(GroupRow{
+		Node: &GroupNode{
+			Title:    "session",
+			Expanded: true,
+			Count:    2,
+		},
+		Level:             0,
+		Width:             80,
+		Styles:            &styles,
+		Now:               fixedNow,
+		EarliestTimestamp: "2025-01-02T08:00:00Z",
+		LatestTimestamp:   "2025-01-02T11:00:00Z",
+	})
+	assert.Contains(t, stripANSI(row), "4h – 1h")
+}
+
+func TestRenderGroupRowDisplaysBadges(t *testing.T) {
+	styles := GroupRowStyles{Base: lipgloss.NewStyle(), Selected: lipgloss.NewStyle()}
+	row := RenderGroupRow(GroupRow{
+		Node: &GroupNode{
+			Title:    "message",
+			Expanded: true,
+			Count:    5,
+		},
+		Level:       0,
+		Width:       120,
+		Styles:      &styles,
+		LevelCounts: map[string]int{"warning": 2, "info": 3},
+	})
+	clean := stripANSI(row)
+	assert.Contains(t, clean, "⚠2")
+	assert.Contains(t, clean, "ℹ3")
+}
+
+func TestRenderGroupRowDisplaysSources(t *testing.T) {
+	styles := GroupRowStyles{Base: lipgloss.NewStyle(), Selected: lipgloss.NewStyle()}
+	options := settings.DefaultGroupHeaderOptions()
+	options.ShowSourceAggregation = true
+	row := RenderGroupRow(GroupRow{
+		Node: &GroupNode{
+			Title:    "group",
+			Expanded: true,
+			Count:    1,
+		},
+		Level:   0,
+		Width:   120,
+		Styles:  &styles,
+		Sources: []string{"pane1", "pane2"},
+		Options: options,
+	})
+	assert.Contains(t, stripANSI(row), "src: pane1,pane2")
 }
 
 func TestFooterGroupedHelpText(t *testing.T) {
@@ -212,6 +273,7 @@ func TestRenderGroupRowWithUnreadCounts(t *testing.T) {
 		Base:     lipgloss.NewStyle(),
 		Selected: lipgloss.NewStyle(),
 	}
+	options := disabledGroupHeaderOptions()
 
 	// Test group with no unread items (should show only total)
 	row := RenderGroupRow(GroupRow{
@@ -222,9 +284,10 @@ func TestRenderGroupRowWithUnreadCounts(t *testing.T) {
 			Count:       5,
 			UnreadCount: 0,
 		},
-		Level:  0,
-		Width:  80,
-		Styles: &styles,
+		Level:   0,
+		Width:   80,
+		Styles:  &styles,
+		Options: options,
 	})
 
 	assert.Contains(t, row, "session-one (5)")
@@ -239,9 +302,10 @@ func TestRenderGroupRowWithUnreadCounts(t *testing.T) {
 			Count:       10,
 			UnreadCount: 3,
 		},
-		Level:  1,
-		Width:  80,
-		Styles: &styles,
+		Level:   1,
+		Width:   80,
+		Styles:  &styles,
+		Options: options,
 	})
 
 	assert.Contains(t, row, "session-two (10/3)")
@@ -252,6 +316,7 @@ func TestRenderGroupRowWithUnreadHighlighting(t *testing.T) {
 		Base:     lipgloss.NewStyle(),
 		Selected: lipgloss.NewStyle(),
 	}
+	options := disabledGroupHeaderOptions()
 
 	// Test that groups with unread items use different styling
 	rowWithUnread := RenderGroupRow(GroupRow{
@@ -262,9 +327,10 @@ func TestRenderGroupRowWithUnreadHighlighting(t *testing.T) {
 			Count:       5,
 			UnreadCount: 2,
 		},
-		Level:  0,
-		Width:  80,
-		Styles: &styles,
+		Level:   0,
+		Width:   80,
+		Styles:  &styles,
+		Options: options,
 	})
 
 	rowAllRead := RenderGroupRow(GroupRow{
@@ -275,9 +341,10 @@ func TestRenderGroupRowWithUnreadHighlighting(t *testing.T) {
 			Count:       5,
 			UnreadCount: 0,
 		},
-		Level:  0,
-		Width:  80,
-		Styles: &styles,
+		Level:   0,
+		Width:   80,
+		Styles:  &styles,
+		Options: options,
 	})
 
 	// Both should render successfully
@@ -293,4 +360,18 @@ func TestRenderGroupRowWithUnreadHighlighting(t *testing.T) {
 
 	// The all-read row should show only the total
 	assert.Contains(t, rowAllRead, "(5)")
+}
+
+func disabledGroupHeaderOptions() settings.GroupHeaderOptions {
+	options := settings.DefaultGroupHeaderOptions()
+	options.ShowTimeRange = false
+	options.ShowLevelBadges = false
+	options.ShowSourceAggregation = false
+	return options
+}
+
+var ansiRegexp = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+func stripANSI(input string) string {
+	return ansiRegexp.ReplaceAllString(input, "")
 }

--- a/internal/tui/service/tree_service_stats.go
+++ b/internal/tui/service/tree_service_stats.go
@@ -1,0 +1,48 @@
+package service
+
+import (
+	"github.com/cristianoliveira/tmux-intray/internal/notification"
+	"github.com/cristianoliveira/tmux-intray/internal/settings"
+	"github.com/cristianoliveira/tmux-intray/internal/tui/model"
+)
+
+func (s *DefaultTreeService) updateUnreadCount(node *model.TreeNode, notif notification.Notification) {
+	if notif.IsRead() {
+		return
+	}
+	node.UnreadCount++
+}
+
+func (s *DefaultTreeService) updateTimeRange(node *model.TreeNode, notif notification.Notification) {
+	if notif.Timestamp == "" {
+		return
+	}
+	if node.LatestEvent == nil || s.isNewerTimestamp(notif.Timestamp, node.LatestEvent.Timestamp) {
+		node.LatestEvent = &notif
+	}
+	if node.EarliestEvent == nil || s.isOlderTimestamp(notif.Timestamp, node.EarliestEvent.Timestamp) {
+		node.EarliestEvent = &notif
+	}
+}
+
+func (s *DefaultTreeService) updateLevelCounts(node *model.TreeNode, notif notification.Notification) {
+	if node.LevelCounts == nil {
+		node.LevelCounts = make(map[string]int)
+	}
+	level := notif.Level
+	if level == "" {
+		level = settings.LevelFilterInfo
+	}
+	node.LevelCounts[level]++
+}
+
+func (s *DefaultTreeService) updateSourceSet(node *model.TreeNode, notif notification.Notification) {
+	if notif.Session == "" && notif.Window == "" && notif.Pane == "" {
+		return
+	}
+	if node.Sources == nil {
+		node.Sources = make(map[string]model.NotificationSource)
+	}
+	src := model.NotificationSource{Session: notif.Session, Window: notif.Window, Pane: notif.Pane}
+	node.Sources[src.SourceKey()] = src
+}

--- a/internal/tui/state/model.go
+++ b/internal/tui/state/model.go
@@ -42,6 +42,8 @@ type Model struct {
 	filters        settings.Filter
 	loadedSettings *settings.Settings // Track loaded settings for comparison
 	settingsSvc    *settingsService
+	// UI render options
+	groupHeaderOptions settings.GroupHeaderOptions
 
 	// Services - implementing BubbleTea nested model pattern
 	treeService         model.TreeService
@@ -114,12 +116,13 @@ func NewModel(client tmux.TmuxClient) (*Model, error) {
 		notificationService: notificationService,
 		settingsSvc:         newSettingsService(),
 		// Legacy fields kept for backward compatibility but now using services
-		client:            client,
-		sessionNames:      runtimeCoordinator.GetSessionNames(),
-		windowNames:       runtimeCoordinator.GetWindowNames(),
-		paneNames:         runtimeCoordinator.GetPaneNames(),
-		ensureTmuxRunning: core.EnsureTmuxRunning,
-		jumpToPane:        core.JumpToPane,
+		client:             client,
+		sessionNames:       runtimeCoordinator.GetSessionNames(),
+		windowNames:        runtimeCoordinator.GetWindowNames(),
+		paneNames:          runtimeCoordinator.GetPaneNames(),
+		ensureTmuxRunning:  core.EnsureTmuxRunning,
+		jumpToPane:         core.JumpToPane,
+		groupHeaderOptions: settings.DefaultGroupHeaderOptions(),
 	}
 
 	// Initialize error handler with callback that sets error message

--- a/internal/tui/state/model_bench_test.go
+++ b/internal/tui/state/model_bench_test.go
@@ -227,14 +227,28 @@ func (s *dummyTreeService) convertNode(stateNode *Node) *model.TreeNode {
 	}
 
 	modelNode := &model.TreeNode{
-		Kind:         model.NodeKind(stateNode.Kind),
-		Title:        stateNode.Title,
-		Display:      stateNode.Display,
-		Expanded:     stateNode.Expanded,
-		Notification: stateNode.Notification,
-		Count:        stateNode.Count,
-		UnreadCount:  stateNode.UnreadCount,
-		LatestEvent:  stateNode.LatestEvent,
+		Kind:          model.NodeKind(stateNode.Kind),
+		Title:         stateNode.Title,
+		Display:       stateNode.Display,
+		Expanded:      stateNode.Expanded,
+		Notification:  stateNode.Notification,
+		Count:         stateNode.Count,
+		UnreadCount:   stateNode.UnreadCount,
+		LatestEvent:   stateNode.LatestEvent,
+		EarliestEvent: stateNode.EarliestEvent,
+	}
+
+	if len(stateNode.LevelCounts) > 0 {
+		modelNode.LevelCounts = make(map[string]int, len(stateNode.LevelCounts))
+		for level, count := range stateNode.LevelCounts {
+			modelNode.LevelCounts[level] = count
+		}
+	}
+	if len(stateNode.Sources) > 0 {
+		modelNode.Sources = make(map[string]model.NotificationSource, len(stateNode.Sources))
+		for key, src := range stateNode.Sources {
+			modelNode.Sources[key] = src
+		}
 	}
 
 	for _, child := range stateNode.Children {

--- a/internal/tui/state/model_notifications.go
+++ b/internal/tui/state/model_notifications.go
@@ -16,6 +16,11 @@ import (
 func (m *Model) SetLoadedSettings(loaded *settings.Settings) {
 	m.ensureSettingsService().setLoadedSettings(loaded)
 	m.loadedSettings = loaded
+	if loaded != nil {
+		m.groupHeaderOptions = loaded.GroupHeader.Clone()
+	} else {
+		m.groupHeaderOptions = settings.DefaultGroupHeaderOptions()
+	}
 }
 
 // ToState converts the Model to a TUIState DTO for settings persistence.

--- a/internal/tui/state/model_render_test.go
+++ b/internal/tui/state/model_render_test.go
@@ -1,0 +1,38 @@
+package state
+
+import (
+	"testing"
+
+	tuimodel "github.com/cristianoliveira/tmux-intray/internal/tui/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGroupSourcesForNodePrefersPaneNames(t *testing.T) {
+	m := &Model{}
+	node := &tuimodel.TreeNode{
+		Sources: map[string]tuimodel.NotificationSource{
+			"pane-a": {Pane: "%2"},
+			"pane-b": {Pane: "%1"},
+		},
+	}
+
+	sources := m.groupSourcesForNode(node)
+	require.Len(t, sources, 2)
+	assert.Equal(t, []string{"%1", "%2"}, sources)
+}
+
+func TestGroupSourcesForNodeBuildsCompositeLabels(t *testing.T) {
+	m := &Model{}
+	node := &tuimodel.TreeNode{
+		Sources: map[string]tuimodel.NotificationSource{
+			"session-only":   {Session: "$1"},
+			"session-window": {Session: "$2", Window: "@3"},
+		},
+	}
+
+	sources := m.groupSourcesForNode(node)
+	require.Len(t, sources, 2)
+	assert.Contains(t, sources, "$1")
+	assert.Contains(t, sources, "$2:@3")
+}

--- a/internal/tui/state/settings_service.go
+++ b/internal/tui/state/settings_service.go
@@ -100,6 +100,12 @@ func applyNonEmptyFilters(src settings.Filter, dest *settings.Filter) {
 
 func (s *settingsService) save(state settings.TUIState) error {
 	nextSettings := state.ToSettings()
+	if s.loadedSettings != nil {
+		nextSettings.GroupHeader = s.loadedSettings.GroupHeader.Clone()
+	} else {
+		defaults := settings.DefaultGroupHeaderOptions()
+		nextSettings.GroupHeader = defaults
+	}
 	if s.loadedSettings != nil && reflect.DeepEqual(*s.loadedSettings, *nextSettings) {
 		return nil
 	}


### PR DESCRIPTION
## Summary
- add groupHeaderOptions settings plus docs and defaults for toggling time range, badges, and source aggregation
- track earliest timestamps, per-level counts, and source metadata through tree/service/state layers and add focused tests
- refactor renderer into helper modules so group rows render time ranges, badges, and sources while satisfying complexity lint

## Testing
- make all