### PR TITLE
chore(logs): add structured logs for critical paths

### DIFF
--- a/cmd/tmux-intray/main.go
+++ b/cmd/tmux-intray/main.go
@@ -4,10 +4,14 @@ import (
 	"os"
 
 	"github.com/cristianoliveira/tmux-intray/cmd"
+	"github.com/cristianoliveira/tmux-intray/internal/colors"
 )
 
 func main() {
+	colors.StructuredInfo("startup", "main", "started", nil, "", nil)
 	if err := cmd.Execute(); err != nil {
+		colors.StructuredError("startup", "main", "failed", err, "", nil)
 		os.Exit(1)
 	}
+	colors.StructuredInfo("startup", "main", "completed", nil, "", nil)
 }

--- a/internal/colors/structured.go
+++ b/internal/colors/structured.go
@@ -1,0 +1,92 @@
+// Package colors provides color output utilities.
+package colors
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+)
+
+var (
+	structuredMu sync.Mutex
+)
+
+// StructuredLogLevel represents log level for structured logs.
+type StructuredLogLevel string
+
+const (
+	LevelDebug StructuredLogLevel = "debug"
+	LevelInfo  StructuredLogLevel = "info"
+	LevelWarn  StructuredLogLevel = "warn"
+	LevelError StructuredLogLevel = "error"
+)
+
+// StructuredLogEntry represents a structured log entry.
+type StructuredLogEntry struct {
+	Timestamp string                 `json:"timestamp"`
+	Level     StructuredLogLevel     `json:"level"`
+	Component string                 `json:"component"`
+	Action    string                 `json:"action"`
+	Status    string                 `json:"status"`
+	Error     string                 `json:"error,omitempty"`
+	ID        string                 `json:"id,omitempty"`
+	Fields    map[string]interface{} `json:"fields,omitempty"`
+}
+
+// StructuredLog writes a structured log entry to stderr.
+// Redaction of sensitive fields should be applied before calling this function.
+func StructuredLog(level StructuredLogLevel, component, action, status string, err error, id string, fields map[string]interface{}) {
+	// Only output debug logs when debug mode is enabled
+	if level == LevelDebug && !debugEnabled {
+		return
+	}
+
+	entry := StructuredLogEntry{
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Level:     level,
+		Component: component,
+		Action:    action,
+		Status:    status,
+		ID:        id,
+		Fields:    fields,
+	}
+	if err != nil {
+		entry.Error = err.Error()
+	}
+
+	data, marshalErr := json.Marshal(entry)
+	if marshalErr != nil {
+		// Fallback to simple log
+		errorFallback(fmt.Sprintf("failed to marshal structured log: %v", marshalErr))
+		return
+	}
+
+	structuredMu.Lock()
+	defer structuredMu.Unlock()
+	_, writeErr := fmt.Fprintf(os.Stderr, "%s\n", data)
+	if writeErr != nil {
+		errorFallback(fmt.Sprintf("failed to write structured log: %v", writeErr))
+	}
+}
+
+// StructuredDebug logs a structured debug entry.
+func StructuredDebug(component, action, status string, err error, id string, fields map[string]interface{}) {
+	StructuredLog(LevelDebug, component, action, status, err, id, fields)
+}
+
+// StructuredInfo logs a structured info entry.
+func StructuredInfo(component, action, status string, err error, id string, fields map[string]interface{}) {
+	StructuredLog(LevelInfo, component, action, status, err, id, fields)
+}
+
+// StructuredWarn logs a structured warning entry.
+func StructuredWarn(component, action, status string, err error, id string, fields map[string]interface{}) {
+	StructuredLog(LevelWarn, component, action, status, err, id, fields)
+}
+
+// StructuredError logs a structured error entry.
+func StructuredError(component, action, status string, err error, id string, fields map[string]interface{}) {
+	StructuredLog(LevelError, component, action, status, err, id, fields)
+}

--- a/internal/storage/init.go
+++ b/internal/storage/init.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/cristianoliveira/tmux-intray/internal/colors"
 	"github.com/cristianoliveira/tmux-intray/internal/config"
@@ -31,6 +32,8 @@ var (
 // Init initializes storage directories.
 // Returns an error if initialization fails. Safe for concurrent calls.
 func Init() error {
+	start := time.Now()
+	colors.StructuredInfo("storage", "init", "started", nil, "", nil)
 	var err error
 	initOnce.Do(func() {
 		// Load configuration
@@ -64,6 +67,7 @@ func Init() error {
 
 	// Return any initialization error from first call
 	if err != nil {
+		colors.StructuredError("storage", "init", "failed", err, "", map[string]interface{}{"duration_seconds": time.Since(start).Seconds()})
 		return err
 	}
 
@@ -71,6 +75,11 @@ func Init() error {
 	initMu.RLock()
 	err = initErr
 	initMu.RUnlock()
+	if err != nil {
+		colors.StructuredError("storage", "init", "failed", err, "", map[string]interface{}{"duration_seconds": time.Since(start).Seconds()})
+		return err
+	}
+	colors.StructuredInfo("storage", "init", "completed", nil, "", map[string]interface{}{"duration_seconds": time.Since(start).Seconds()})
 	return err
 }
 

--- a/internal/tmux/client.go
+++ b/internal/tmux/client.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"time"
 
+	"github.com/cristianoliveira/tmux-intray/internal/colors"
 	"github.com/cristianoliveira/tmux-intray/internal/errors"
 )
 
@@ -90,6 +91,12 @@ func NewDefaultClient(opts ...ClientOption) *DefaultClient {
 // runCommand executes a tmux command with the given arguments.
 // It returns stdout, stderr, and any error that occurred.
 func (c *DefaultClient) runCommand(args ...string) (string, string, error) {
+	start := time.Now()
+	command := ""
+	if len(args) > 0 {
+		command = args[0]
+	}
+	colors.StructuredDebug("tmux", "run", "started", nil, command, map[string]interface{}{"args_count": len(args)})
 	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
 	defer cancel()
 
@@ -105,6 +112,12 @@ func (c *DefaultClient) runCommand(args ...string) (string, string, error) {
 	cmd.Stderr = &stderr
 
 	err := cmd.Run()
+	duration := time.Since(start).Seconds()
+	if err != nil {
+		colors.StructuredError("tmux", "run", "failed", err, command, map[string]interface{}{"args_count": len(args), "duration_seconds": duration})
+	} else {
+		colors.StructuredDebug("tmux", "run", "completed", nil, command, map[string]interface{}{"args_count": len(args), "duration_seconds": duration})
+	}
 	return stdout.String(), stderr.String(), err
 }
 

--- a/internal/tmux/navigation.go
+++ b/internal/tmux/navigation.go
@@ -9,7 +9,21 @@ import (
 )
 
 // jumpToPane is the private implementation that accepts a custom error handler.
-func (c *DefaultClient) jumpToPane(sessionID, windowID, paneID string, handler errors.ErrorHandler) (bool, error) {
+func (c *DefaultClient) jumpToPane(sessionID, windowID, paneID string, handler errors.ErrorHandler) (ok bool, err error) {
+	fields := map[string]interface{}{
+		"session_id": sessionID,
+		"window_id":  windowID,
+		"pane_id":    paneID,
+	}
+	colors.StructuredInfo("tmux", "jump", "started", nil, "", fields)
+	defer func() {
+		if err != nil {
+			colors.StructuredError("tmux", "jump", "failed", err, "", fields)
+			return
+		}
+		colors.StructuredInfo("tmux", "jump", "completed", nil, "", fields)
+	}()
+
 	// Validate required fields (sessionID and windowID)
 	if sessionID == "" || windowID == "" {
 		return false, ErrInvalidTarget


### PR DESCRIPTION
## Summary
- add structured log helper for JSON stderr output
- log CLI startup/command execution and storage init with durations
- add tmux command/jump structured logging for critical paths

## Testing
- go test ./internal/tmux ./internal/storage ./internal/hooks ./cmd/tmux-intray