### PR TITLE
fix(tui): don't render success messages as errors

### DIFF
--- a/internal/tui/state/model_actions.go
+++ b/internal/tui/state/model_actions.go
@@ -135,8 +135,7 @@ func (m *Model) handleDismissByFilter(session, window, pane string) tea.Cmd {
 
 	// Show success message
 	m.errorHandler.Success("Notifications dismissed")
-
-	return nil
+	return errorMsgAfter(errorClearDuration)
 }
 
 // markSelectedRead marks the selected notification as read.

--- a/internal/tui/state/model_render.go
+++ b/internal/tui/state/model_render.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/cristianoliveira/tmux-intray/internal/colors"
+	"github.com/cristianoliveira/tmux-intray/internal/errors"
 	"github.com/cristianoliveira/tmux-intray/internal/notification"
 	"github.com/cristianoliveira/tmux-intray/internal/settings"
 	"github.com/cristianoliveira/tmux-intray/internal/tui/model"
@@ -63,11 +64,27 @@ func (m *Model) View() string {
 	s.WriteString("\n")
 	s.WriteString(m.uiState.GetViewport().View())
 
-	// Error message above footer
-	if m.errorMessage != "" {
+	// Status message above footer
+	if m.hasStatusMessage {
 		s.WriteString("\n")
-		errorStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ansiColorNumber(colors.Red)))
-		s.WriteString(errorStyle.Render("Error: " + m.errorMessage))
+		prefix := ""
+		color := colors.Red
+		switch m.statusMessageType {
+		case errors.MessageTypeWarning:
+			prefix = "Warning: "
+			color = colors.Yellow
+		case errors.MessageTypeInfo:
+			prefix = "Info: "
+			color = colors.Blue
+		case errors.MessageTypeSuccess:
+			prefix = "Success: "
+			color = colors.Green
+		default:
+			prefix = "Error: "
+			color = colors.Red
+		}
+		style := lipgloss.NewStyle().Foreground(lipgloss.Color(ansiColorNumber(color)))
+		s.WriteString(style.Render(prefix + m.statusMessage))
 	}
 
 	// Footer
@@ -78,7 +95,7 @@ func (m *Model) View() string {
 		Grouped:      m.isGroupedView(),
 		ViewMode:     string(m.uiState.GetViewMode()),
 		Width:        m.uiState.GetWidth(),
-		ErrorMessage: m.errorMessage,
+		ErrorMessage: m.statusMessage,
 		ReadFilter:   m.filters.Read,
 		ShowHelp:     m.uiState.ShowHelp(),
 	}))

--- a/internal/tui/state/model_test.go
+++ b/internal/tui/state/model_test.go
@@ -1693,6 +1693,22 @@ func TestModelViewWithNoNotifications(t *testing.T) {
 	assert.Contains(t, view, "No notifications found")
 }
 
+func TestModelViewRendersSuccessMessageWithoutErrorPrefix(t *testing.T) {
+	model := newTestModel(t, []notification.Notification{})
+	model.uiState.SetWidth(80)
+	model.uiState.SetHeight(24)
+	model.updateViewportContent()
+
+	model.statusMessage = "Notifications dismissed"
+	model.statusMessageType = errors.MessageTypeSuccess
+	model.hasStatusMessage = true
+
+	view := model.View()
+
+	assert.Contains(t, view, "Success: Notifications dismissed")
+	assert.NotContains(t, view, "Error: Notifications dismissed")
+}
+
 func TestModelViewRendersCurrentViewModeInFooter(t *testing.T) {
 	model := newTestModel(t, []notification.Notification{})
 	model.uiState.SetWidth(80)


### PR DESCRIPTION
## Why
Grouped dismiss could render a successful status message with an `Error:` prefix, which was misleading in the TUI.

## What
- Preserve status message type when rendering
- Render the correct prefix/color by type so success stays success

## Tests
- `make tests`
- `make lint`
