### PR TITLE
feat(poc): add message deduplication (3 messages per pane)

### DIFF
--- a/internal/tui/service/tree_service.go
+++ b/internal/tui/service/tree_service.go
@@ -63,6 +63,30 @@ func (s *DefaultTreeService) BuildTree(notifications []notification.Notification
 		messageKeys = dedup.BuildKeys(records, dedupconfig.Load())
 	}
 
+	s.processNotifications(
+		root,
+		notifications,
+		includeSession, includeWindow, includePane, groupByMessage,
+		sessionNodes, windowNodes, paneNodes, messageNodes,
+		messageKeys,
+	)
+
+	s.sortTree(root)
+	s.finalizeTree(root)
+
+	s.treeRoot = root
+	s.InvalidateCache()
+	return nil
+}
+
+// processNotifications processes all notifications and builds the tree structure.
+func (s *DefaultTreeService) processNotifications(
+	root *model.TreeNode,
+	notifications []notification.Notification,
+	includeSession, includeWindow, includePane, groupByMessage bool,
+	sessionNodes, windowNodes, paneNodes, messageNodes map[string]*model.TreeNode,
+	messageKeys []string,
+) {
 	for idx, notif := range notifications {
 		current := notif
 		parent := root
@@ -105,13 +129,6 @@ func (s *DefaultTreeService) BuildTree(notifications []notification.Notification
 
 		s.incrementGroupStats(root, current)
 	}
-
-	s.sortTree(root)
-	s.finalizeTree(root)
-
-	s.treeRoot = root
-	s.InvalidateCache()
-	return nil
 }
 
 // finalizeTree performs final tree processing: limiting messages and updating counts.


### PR DESCRIPTION
- Limits each pane to 3 most recent messages
- Unread messages are prioritized (shown at top)
- Messages sorted: unread first → newest first
- UI counts updated correctly (e.g., (3/3) instead of (4/4))

POC for validation. Configurable limit coming in full implementation.