### PR TITLE
fix(tui): prevent structured JSON logs from interfering with TUI display

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cristianoliveira/tmux-intray/internal/colors"
 	"github.com/cristianoliveira/tmux-intray/internal/hooks"
+	"github.com/cristianoliveira/tmux-intray/internal/logging"
 	"github.com/cristianoliveira/tmux-intray/internal/version"
 	"github.com/spf13/cobra"
 )
@@ -86,15 +87,22 @@ func init() {
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() error {
 	args := os.Args[1:]
+
+	// Disable structured logging for TUI command to avoid JSON output interfering with display
+	isTUICommand := len(args) > 0 && args[0] == "tui"
+	if isTUICommand {
+		colors.DisableStructuredLogging()
+		logging.DisableStructuredLogging()
+		defer colors.EnableStructuredLogging()
+		defer logging.EnableStructuredLogging()
+	}
+
 	colors.StructuredInfo("cli/root", "execute", "started", nil, "", map[string]interface{}{"arg_count": len(args)})
 	defer hooks.WaitForPendingHooks()
 	if err := hooks.Init(); err != nil {
 		colors.StructuredError("cli/root", "execute", "hooks_init_failed", err, "", nil)
 		return err
 	}
-
-	// DEBUG: print commands
-	// fmt.Fprintf(os.Stderr, "DEBUG: commands: %v\n", RootCmd.Commands())
 
 	// No args? show help by routing through cobra help command
 	if len(args) == 0 {

--- a/cmd/tmux-intray/main.go
+++ b/cmd/tmux-intray/main.go
@@ -8,10 +8,22 @@ import (
 )
 
 func main() {
-	colors.StructuredInfo("startup", "main", "started", nil, "", nil)
+	// Disable structured logging for TUI command to avoid JSON output interfering with display
+	args := os.Args[1:]
+	isTUICommand := len(args) > 0 && args[0] == "tui"
+
+	if !isTUICommand {
+		colors.StructuredInfo("startup", "main", "started", nil, "", nil)
+	}
+
 	if err := cmd.Execute(); err != nil {
-		colors.StructuredError("startup", "main", "failed", err, "", nil)
+		if !isTUICommand {
+			colors.StructuredError("startup", "main", "failed", err, "", nil)
+		}
 		os.Exit(1)
 	}
-	colors.StructuredInfo("startup", "main", "completed", nil, "", nil)
+
+	if !isTUICommand {
+		colors.StructuredInfo("startup", "main", "completed", nil, "", nil)
+	}
 }


### PR DESCRIPTION
## Summary
Fixed a bug where structured JSON logs were appearing in the console when running `tmux-intray tui`, which interfered with the TUI display.

## Changes
- Added `DisableStructuredLogging()` and `EnableStructuredLogging()` helpers to both `colors` and `logging` packages using atomic flags for thread safety
- Modified TUI command execution in `cmd/root.go` to disable structured logging before TUI starts, with `defer` cleanup to restore logging after completion
- Modified `cmd/tmux-intray/main.go` to skip startup logs when TUI command is detected
- Extended fix to cover both logging systems (`colors` and `logging` packages) since both emit structured logs

## Testing
- ✅ `tmux-intray tui` produces no JSON log output
- ✅ Other commands (`tmux-intray list`, `tmux-intray help`) still log correctly
- ✅ All quality gates pass (lint, tests, build, format)
- ✅ No breaking changes to existing functionality

## Related
Fixes issue: tmux-intray-u2bs