### PR TITLE
wro2.6: decouple sqlite storage from tmux

### DIFF
--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/cristianoliveira/tmux-intray/internal/config"
 	"github.com/cristianoliveira/tmux-intray/internal/storage/sqlite"
+	"github.com/cristianoliveira/tmux-intray/internal/tmux"
 )
 
 const (
@@ -28,6 +29,7 @@ func NewForBackend(backend string) (Storage, error) {
 	switch backend {
 	case BackendSQLite:
 		dbPath := filepath.Join(GetStateDir(), "notifications.db")
+		sqlite.SetTmuxClient(tmux.NewDefaultClient())
 		sqliteStorage, err := sqlite.NewSQLiteStorage(dbPath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to initialize sqlite backend: %w", err)

--- a/internal/storage/sqlite/tmux.go
+++ b/internal/storage/sqlite/tmux.go
@@ -8,10 +8,19 @@ import (
 
 	"github.com/cristianoliveira/tmux-intray/internal/colors"
 	"github.com/cristianoliveira/tmux-intray/internal/ports"
-	"github.com/cristianoliveira/tmux-intray/internal/tmux"
 )
 
-var tmuxClient ports.StatusPublisher = tmux.NewDefaultClient()
+type noopStatusPublisher struct{}
+
+func (noopStatusPublisher) HasSession() (bool, error) {
+	return false, nil
+}
+
+func (noopStatusPublisher) SetStatusOption(name, value string) error {
+	return nil
+}
+
+var tmuxClient ports.StatusPublisher = noopStatusPublisher{}
 
 // SetTmuxClient sets the tmux client used for status updates.
 func SetTmuxClient(client ports.StatusPublisher) {


### PR DESCRIPTION
## Summary
- remove direct internal/tmux dependency from internal/storage/sqlite
- keep active-count/status updates via injected status publisher wiring in storage factory
- update storage tests to use local status publisher mock without tmux import

## Validation
- go test ./internal/storage/... ./internal/tmuxintray
- make lint-strict
- make security-check
- make check-fmt
- make tests
- make go-build
- make check-coverage THRESHOLD=65