### PR TITLE
wro2.8: route TUI dependencies through app adapter

### DIFF
--- a/cmd/tmux-intray/tui.go
+++ b/cmd/tmux-intray/tui.go
@@ -7,19 +7,17 @@ import (
 	"fmt"
 	"os"
 
-	tea "github.com/charmbracelet/bubbletea"
 	"github.com/cristianoliveira/tmux-intray/cmd"
 	"github.com/cristianoliveira/tmux-intray/internal/colors"
 	"github.com/cristianoliveira/tmux-intray/internal/settings"
-	"github.com/cristianoliveira/tmux-intray/internal/tmux"
-	"github.com/cristianoliveira/tmux-intray/internal/tui/state"
+	"github.com/cristianoliveira/tmux-intray/internal/tui/app"
 	"github.com/spf13/cobra"
 )
 
 type tuiClient interface {
 	LoadSettings() (*settings.Settings, error)
-	CreateModel() (*state.Model, error)
-	RunProgram(model *state.Model) error
+	CreateModel() (app.Model, error)
+	RunProgram(model app.Model) error
 }
 
 // NewTUICmd creates the tui command with explicit dependencies.
@@ -81,40 +79,8 @@ USAGE:
 	}
 }
 
-// defaultTUIClient is the default implementation.
-type defaultTUIClient struct {
-	tmuxClient tmux.TmuxClient
-}
-
-func (d *defaultTUIClient) LoadSettings() (*settings.Settings, error) {
-	return settings.Load()
-}
-
-func (d *defaultTUIClient) CreateModel() (*state.Model, error) {
-	if d.tmuxClient == nil {
-		d.tmuxClient = tmux.NewDefaultClient()
-	}
-	return state.NewModel(d.tmuxClient)
-}
-
-func (d *defaultTUIClient) RunProgram(model *state.Model) error {
-	p := tea.NewProgram(
-		model,
-		tea.WithAltScreen(),
-		tea.WithMouseCellMotion(),
-	)
-
-	// Start the program
-	_, err := p.Run()
-	if err != nil {
-		colors.Error(fmt.Sprintf("Error running TUI: %v", err))
-		os.Exit(1)
-	}
-	return nil
-}
-
 // tuiCmd represents the tui command
-var tuiCmd = NewTUICmd(&defaultTUIClient{})
+var tuiCmd = NewTUICmd(app.NewDefaultClient(nil))
 
 func init() {
 	cmd.RootCmd.AddCommand(tuiCmd)

--- a/internal/tui/app/client.go
+++ b/internal/tui/app/client.go
@@ -1,0 +1,66 @@
+// Package app provides TUI application adapters for command wiring.
+package app
+
+import (
+	"fmt"
+	"os"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/cristianoliveira/tmux-intray/internal/colors"
+	"github.com/cristianoliveira/tmux-intray/internal/settings"
+	"github.com/cristianoliveira/tmux-intray/internal/tmux"
+	"github.com/cristianoliveira/tmux-intray/internal/tui/state"
+)
+
+// Model defines the narrow TUI model surface used by command wiring.
+type Model interface {
+	tea.Model
+	SetLoadedSettings(loadedSettings *settings.Settings)
+	FromState(settingsState settings.TUIState) error
+}
+
+// Client defines dependencies needed by the tui command.
+type Client interface {
+	LoadSettings() (*settings.Settings, error)
+	CreateModel() (Model, error)
+	RunProgram(model Model) error
+}
+
+// DefaultClient is the default adapter-based implementation used by CLI wiring.
+type DefaultClient struct {
+	tmuxClient tmux.TmuxClient
+}
+
+// NewDefaultClient creates a default TUI client adapter.
+func NewDefaultClient(tmuxClient tmux.TmuxClient) *DefaultClient {
+	return &DefaultClient{tmuxClient: tmuxClient}
+}
+
+// LoadSettings loads persisted settings.
+func (d *DefaultClient) LoadSettings() (*settings.Settings, error) {
+	return settings.Load()
+}
+
+// CreateModel builds a TUI model implementation.
+func (d *DefaultClient) CreateModel() (Model, error) {
+	if d.tmuxClient == nil {
+		d.tmuxClient = tmux.NewDefaultClient()
+	}
+	return state.NewModel(d.tmuxClient)
+}
+
+// RunProgram starts the bubbletea program.
+func (d *DefaultClient) RunProgram(model Model) error {
+	p := tea.NewProgram(
+		model,
+		tea.WithAltScreen(),
+		tea.WithMouseCellMotion(),
+	)
+
+	_, err := p.Run()
+	if err != nil {
+		colors.Error(fmt.Sprintf("Error running TUI: %v", err))
+		os.Exit(1)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- route TUI command wiring through internal/tui/app adapter interfaces
- reduce direct broad dependency surface from command and state wiring
- preserve view modes and key flows while narrowing integration boundaries

## Validation
- go test ./internal/tui/...
- go test ./cmd/tmux-intray/...
- make go-build
- make tests
- make lint-strict
- make security-check
- make check-coverage THRESHOLD=65