### PR TITLE
wro2.10: integrate dependency guardrails into CI and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,9 @@ jobs:
       - name: Run lint
         run: make lint-strict
 
+      - name: Run dependency guardrails
+        run: make check-import-deny-rules
+
       - name: Run security check
         run: make security-check
 

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ lint: check-fmt go-lint go-complexity-lint
 	@echo "Running linter..."
 	./scripts/lint.sh
 
-lint-strict: check-fmt go-lint go-complexity-lint-strict
+lint-strict: check-fmt go-lint go-complexity-lint-strict check-import-deny-rules
 	@echo "Running strict linter..."
 	./scripts/lint.sh
 

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -18,8 +18,9 @@ Runs on every push to `main` and `develop` branches, and on pull requests target
    - Ubuntu 22.04
    - Uses `make tests`
 
-2. **code-quality** - Runs linting and security checks:
-   - Lint: `make lint` (includes ShellCheck and formatting check)
+2. **code-quality** - Runs strict linting and security checks:
+   - Lint: `make lint-strict` (includes ShellCheck, formatting check, and dependency guardrails)
+   - Dependency guardrails: `make check-import-deny-rules`
    - Security: `make security-check` (security-focused ShellCheck)
    - Runs on Ubuntu latest
 
@@ -31,10 +32,7 @@ Runs on every push to `main` and `develop` branches, and on pull requests target
 4. **install-linux** - Tests installation methods on Linux:
    - npm installation
    - Go binary build
- 
    - Source installation
-
-
 
 ### Release (`release.yml`)
 
@@ -98,7 +96,8 @@ pre-commit install
 - Environment variables: `TMUX_INTRAY_CONFIG_LOADED=1`, `TMUX_INTRAY_DEBUG=0`
 
 #### Lint/Security Failures
-- Run `make lint` locally to see ShellCheck errors
+- Run `make lint-strict` locally to reproduce CI lint failures
+- Run `make check-import-deny-rules` for dependency layering violations
 - Run `make security-check` for security-specific warnings
 - Use `make fmt` to auto-format shell scripts
 
@@ -106,15 +105,11 @@ pre-commit install
 - npm installation: ensure package.json is valid
 - Go build: check Go version compatibility
 
-
-
 ### Release Failures
 
 #### Version Mismatch
 Error: "Version mismatch between bin/tmux-intray and git tag"
 - Ensure the `VERSION` variable in `bin/tmux-intray` matches the git tag (without leading 'v')
-
-
 
 ## Extending the Pipeline
 
@@ -131,8 +126,6 @@ Error: "Version mismatch between bin/tmux-intray and git tag"
 1. Edit `.github/workflows/release.yml`
 2. Add build steps in `create-release` job
 3. Add artifacts to the `files` list in the "Create GitHub Release" step
-
-
 
 ## Monitoring
 

--- a/docs/design/import-layering-map.md
+++ b/docs/design/import-layering-map.md
@@ -86,3 +86,20 @@ Run dependency deny-rules guard locally:
 
 - `./scripts/check-import-deny-rules.sh`
 - `make check-import-deny-rules`
+- `make lint-strict` (includes `check-import-deny-rules`)
+
+The CI lint job also executes `make check-import-deny-rules` as an explicit
+dependency guardrails step.
+
+## Updating Guardrail Rules
+
+When architecture rules change, update both guardrail sources:
+
+1. Layer mapping and denied edges in `scripts/check-import-deny-rules.sh`
+2. Package-level deny rules in `.golangci.yml` (`linters.settings.depguard.rules`)
+
+After updating rules:
+
+- Run `make check-import-deny-rules`
+- Run `golangci-lint run`
+- If package boundaries moved, regenerate baseline with `make import-graph`


### PR DESCRIPTION
## Summary
- run dependency deny-rules check in CI lint workflow
- include guardrail check in strict local linting flow
- document local usage and rule-update workflow for dependency guardrails

## Validation
- make check-import-deny-rules
- make lint-strict
- make tests
- make security-check
- make check-fmt
- make go-build
- make check-coverage THRESHOLD=65