### PR TITLE
chore: enforce dependency guardrails in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,3 +34,9 @@ repos:
         entry: scripts/go-pre-commit.sh
         language: system
         files: \.go$
+      - id: check-import-deny-rules
+        name: Check import deny rules
+        entry: make check-import-deny-rules
+        language: system
+        always_run: true
+        pass_filenames: false


### PR DESCRIPTION
## Summary
- add a local pre-commit hook that runs make check-import-deny-rules
- run the guardrail hook on every commit (always_run true, pass_filenames false)
- enforce architecture dependency rules before code reaches CI

## Validation
- make check-import-deny-rules