### PR TITLE
feat(tui): implement Recents/All filtering semantics

### DIFF
--- a/internal/tui/model/notification_service.go
+++ b/internal/tui/model/notification_service.go
@@ -4,6 +4,7 @@ package model
 
 import (
 	"github.com/cristianoliveira/tmux-intray/internal/notification"
+	"github.com/cristianoliveira/tmux-intray/internal/settings"
 )
 
 // NotificationService defines the interface for notification business logic operations.
@@ -18,8 +19,8 @@ type NotificationService interface {
 	// GetFilteredNotifications returns the latest filtered notification view.
 	GetFilteredNotifications() []notification.Notification
 
-	// ApplyFiltersAndSearch applies filters/search/sorting and stores filtered results.
-	ApplyFiltersAndSearch(query, state, level, sessionID, windowID, paneID, readFilter, sortBy, sortOrder string)
+	// ApplyFiltersAndSearch applies tab selection, filters/search/sorting, and stores filtered results.
+	ApplyFiltersAndSearch(activeTab settings.Tab, query, state, level, sessionID, windowID, paneID, readFilter, sortBy, sortOrder string)
 
 	// FilterNotifications filters notifications based on a search query.
 	// Returns a list of matching notifications.

--- a/internal/tui/service/notification_service_test.go
+++ b/internal/tui/service/notification_service_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/cristianoliveira/tmux-intray/internal/notification"
+	"github.com/cristianoliveira/tmux-intray/internal/settings"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -62,7 +63,7 @@ func TestApplyFiltersAndSearchRespectsReadFilter(t *testing.T) {
 	}
 
 	svc.SetNotifications(notifications)
-	svc.ApplyFiltersAndSearch("", "", "", "", "", "", "unread", "timestamp", "asc")
+	svc.ApplyFiltersAndSearch(settings.TabRecents, "", "", "", "", "", "", "unread", "timestamp", "asc")
 	filtered := svc.GetFilteredNotifications()
 	require.Len(t, filtered, 1)
 	assert.Equal(t, 1, filtered[0].ID)
@@ -117,20 +118,20 @@ func TestApplyFiltersAndSearchLevelFilter(t *testing.T) {
 	svc.SetNotifications(notifications)
 
 	// Filter by level "error"
-	svc.ApplyFiltersAndSearch("", "", "error", "", "", "", "", "timestamp", "asc")
+	svc.ApplyFiltersAndSearch(settings.TabRecents, "", "", "error", "", "", "", "", "timestamp", "asc")
 	filtered := svc.GetFilteredNotifications()
 	require.Len(t, filtered, 2)
 	assert.Equal(t, 1, filtered[0].ID)
 	assert.Equal(t, 3, filtered[1].ID)
 
 	// Filter by level "warning"
-	svc.ApplyFiltersAndSearch("", "", "warning", "", "", "", "", "timestamp", "asc")
+	svc.ApplyFiltersAndSearch(settings.TabRecents, "", "", "warning", "", "", "", "", "timestamp", "asc")
 	filtered = svc.GetFilteredNotifications()
 	require.Len(t, filtered, 1)
 	assert.Equal(t, 2, filtered[0].ID)
 
 	// Filter by level "info"
-	svc.ApplyFiltersAndSearch("", "", "info", "", "", "", "", "timestamp", "asc")
+	svc.ApplyFiltersAndSearch(settings.TabRecents, "", "", "info", "", "", "", "", "timestamp", "asc")
 	filtered = svc.GetFilteredNotifications()
 	require.Len(t, filtered, 1)
 	assert.Equal(t, 4, filtered[0].ID)
@@ -148,14 +149,14 @@ func TestApplyFiltersAndSearchSessionWindowPaneFilter(t *testing.T) {
 	svc.SetNotifications(notifications)
 
 	// Filter by session "$1"
-	svc.ApplyFiltersAndSearch("", "", "", "$1", "", "", "", "timestamp", "asc")
+	svc.ApplyFiltersAndSearch(settings.TabRecents, "", "", "", "$1", "", "", "", "timestamp", "asc")
 	filtered := svc.GetFilteredNotifications()
 	require.Len(t, filtered, 2)
 	assert.Equal(t, 1, filtered[0].ID)
 	assert.Equal(t, 2, filtered[1].ID)
 
 	// Filter by window "@1"
-	svc.ApplyFiltersAndSearch("", "", "", "", "@1", "", "", "timestamp", "asc")
+	svc.ApplyFiltersAndSearch(settings.TabRecents, "", "", "", "", "@1", "", "", "timestamp", "asc")
 	filtered = svc.GetFilteredNotifications()
 	require.Len(t, filtered, 3)
 	assert.Equal(t, 1, filtered[0].ID)
@@ -163,7 +164,7 @@ func TestApplyFiltersAndSearchSessionWindowPaneFilter(t *testing.T) {
 	assert.Equal(t, 3, filtered[2].ID)
 
 	// Filter by pane "%1"
-	svc.ApplyFiltersAndSearch("", "", "", "", "", "%1", "", "timestamp", "asc")
+	svc.ApplyFiltersAndSearch(settings.TabRecents, "", "", "", "", "", "%1", "", "timestamp", "asc")
 	filtered = svc.GetFilteredNotifications()
 	require.Len(t, filtered, 3)
 	assert.Equal(t, 1, filtered[0].ID)
@@ -171,8 +172,82 @@ func TestApplyFiltersAndSearchSessionWindowPaneFilter(t *testing.T) {
 	assert.Equal(t, 4, filtered[2].ID)
 
 	// Combined session and pane
-	svc.ApplyFiltersAndSearch("", "", "", "$1", "", "%1", "", "timestamp", "asc")
+	svc.ApplyFiltersAndSearch(settings.TabRecents, "", "", "", "$1", "", "%1", "", "timestamp", "asc")
 	filtered = svc.GetFilteredNotifications()
 	require.Len(t, filtered, 1)
 	assert.Equal(t, 1, filtered[0].ID)
+}
+
+func TestApplyFiltersAndSearchActiveOnlyAcrossTabs(t *testing.T) {
+	svc := NewNotificationService(nil, nil)
+	notifications := []notification.Notification{
+		{ID: 1, Message: "active 1", Timestamp: "2024-01-01T10:00:00Z", State: "active", Level: "info"},
+		{ID: 2, Message: "dismissed", Timestamp: "2024-01-02T10:00:00Z", State: "dismissed", Level: "info"},
+		{ID: 3, Message: "active 2", Timestamp: "2024-01-03T10:00:00Z", State: "active", Level: "warning"},
+	}
+	svc.SetNotifications(notifications)
+
+	svc.ApplyFiltersAndSearch(settings.TabRecents, "", "", "", "", "", "", "", "timestamp", "desc")
+	filtered := svc.GetFilteredNotifications()
+	require.Len(t, filtered, 2)
+	assert.Equal(t, []int{3, 1}, []int{filtered[0].ID, filtered[1].ID})
+
+	svc.ApplyFiltersAndSearch(settings.TabAll, "", "", "", "", "", "", "", "timestamp", "desc")
+	filtered = svc.GetFilteredNotifications()
+	require.Len(t, filtered, 2)
+	assert.Equal(t, []int{3, 1}, []int{filtered[0].ID, filtered[1].ID})
+}
+
+func TestApplyFiltersAndSearchRecentsUsesLimitedDataset(t *testing.T) {
+	svc := NewNotificationService(nil, nil)
+	notifications := make([]notification.Notification, 0, 25)
+	for i := 1; i <= 25; i++ {
+		notifications = append(notifications, notification.Notification{
+			ID:        i,
+			Message:   "msg",
+			Timestamp: "2024-01-01T10:00:00Z",
+			State:     "active",
+			Level:     "info",
+		})
+	}
+	svc.SetNotifications(notifications)
+
+	svc.ApplyFiltersAndSearch(settings.TabRecents, "", "", "", "", "", "", "", "id", "desc")
+	filtered := svc.GetFilteredNotifications()
+	require.Len(t, filtered, 20)
+	assert.Equal(t, 25, filtered[0].ID)
+	assert.Equal(t, 6, filtered[len(filtered)-1].ID)
+
+	svc.ApplyFiltersAndSearch(settings.TabAll, "", "", "", "", "", "", "", "id", "desc")
+	filtered = svc.GetFilteredNotifications()
+	require.Len(t, filtered, 25)
+	assert.Equal(t, 25, filtered[0].ID)
+	assert.Equal(t, 1, filtered[len(filtered)-1].ID)
+}
+
+func TestApplyFiltersAndSearchScopesFilteringToSelectedTabDataset(t *testing.T) {
+	svc := NewNotificationService(nil, nil)
+	notifications := make([]notification.Notification, 0, 25)
+	for i := 1; i <= 25; i++ {
+		level := "info"
+		if i == 2 {
+			level = "error"
+		}
+		notifications = append(notifications, notification.Notification{
+			ID:        i,
+			Message:   "msg",
+			Timestamp: "2024-01-01T10:00:00Z",
+			State:     "active",
+			Level:     level,
+		})
+	}
+	svc.SetNotifications(notifications)
+
+	svc.ApplyFiltersAndSearch(settings.TabRecents, "", "", "error", "", "", "", "", "id", "desc")
+	assert.Empty(t, svc.GetFilteredNotifications())
+
+	svc.ApplyFiltersAndSearch(settings.TabAll, "", "", "error", "", "", "", "", "id", "desc")
+	filtered := svc.GetFilteredNotifications()
+	require.Len(t, filtered, 1)
+	assert.Equal(t, 2, filtered[0].ID)
 }

--- a/internal/tui/state/model_bench_test.go
+++ b/internal/tui/state/model_bench_test.go
@@ -565,7 +565,7 @@ func (d *dummyNotificationService) FilterByReadStatus(notifications []notificati
 	return filtered
 }
 
-func (d *dummyNotificationService) ApplyFiltersAndSearch(query, state, level, sessionID, windowID, paneID, readFilter, sortBy, sortOrder string) {
+func (d *dummyNotificationService) ApplyFiltersAndSearch(_ settings.Tab, query, state, level, sessionID, windowID, paneID, readFilter, sortBy, sortOrder string) {
 	result := d.notifications
 
 	if state != "" {

--- a/internal/tui/state/model_notifications.go
+++ b/internal/tui/state/model_notifications.go
@@ -120,6 +120,7 @@ func (m *Model) applySearchFilter() {
 	}
 
 	notificationService.ApplyFiltersAndSearch(
+		m.uiState.GetActiveTab(),
 		m.uiState.GetSearchQuery(),
 		m.filters.State,
 		m.filters.Level,


### PR DESCRIPTION
## Summary
- apply tab-scoped dataset selection in notification service using the shared `settings.Tab` contract before filter/search/sort
- enforce active-only semantics for both tabs, with Recents limited to the most recent active subset and All using the full active set
- add service/state tests that cover active-only behavior, tab-scoped filtering, and tab-switch refresh with preserved search query

## Validation
- go test ./internal/tui/service ./internal/tui/state
- go test ./...
- make all