### PR TITLE
refactor(cli): decouple composition root and follow tick handling

### DIFF
--- a/cmd/tmux-intray/add.go
+++ b/cmd/tmux-intray/add.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cristianoliveira/tmux-intray/cmd"
 	"github.com/cristianoliveira/tmux-intray/internal/colors"
 	"github.com/spf13/cobra"
 )
@@ -114,13 +113,6 @@ func runAddCmd(client addClient, args []string, sessionFlag, windowFlag, paneFla
 
 	colors.Success("added")
 	return nil
-}
-
-// addCmd represents the add command.
-var addCmd = NewAddCmd(coreClient)
-
-func init() {
-	cmd.RootCmd.AddCommand(addCmd)
 }
 
 // validateMessage checks message length and emptiness (matches Bash validation)

--- a/cmd/tmux-intray/cleanup.go
+++ b/cmd/tmux-intray/cleanup.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/cristianoliveira/tmux-intray/cmd"
 	"github.com/cristianoliveira/tmux-intray/internal/config"
 	"github.com/spf13/cobra"
 )
@@ -69,11 +68,4 @@ than the configured auto-cleanup days. This helps prevent storage bloat.`,
 	cleanupCmd.Flags().BoolVar(&dryRunFlag, "dryrun", false, "Show what would be deleted without actually deleting")
 
 	return cleanupCmd
-}
-
-// cleanupCmd represents the cleanup command.
-var cleanupCmd = NewCleanupCmd(coreClient)
-
-func init() {
-	cmd.RootCmd.AddCommand(cleanupCmd)
 }

--- a/cmd/tmux-intray/clear.go
+++ b/cmd/tmux-intray/clear.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/cristianoliveira/tmux-intray/cmd"
 	"github.com/cristianoliveira/tmux-intray/internal/colors"
 	"github.com/spf13/cobra"
 )
@@ -72,18 +71,12 @@ EXAMPLES:
 	return clearCmd
 }
 
-// clearCmd represents the clear command.
-var clearCmd = NewClearCmd(coreClient)
-
-func init() {
-	cmd.RootCmd.AddCommand(clearCmd)
-}
-
-var clearAllFunc = func() error {
-	return fileStorage.DismissAll()
-}
+var clearAllFunc func() error
 
 func ClearAll() error {
+	if clearAllFunc == nil {
+		return fmt.Errorf("clear: missing storage dependency")
+	}
 	return clearAllFunc()
 }
 

--- a/cmd/tmux-intray/deps.go
+++ b/cmd/tmux-intray/deps.go
@@ -1,9 +1,89 @@
 package main
 
 import (
+	"fmt"
+	"sync"
+
+	"github.com/cristianoliveira/tmux-intray/cmd"
 	"github.com/cristianoliveira/tmux-intray/internal/core"
+	"github.com/cristianoliveira/tmux-intray/internal/ports"
+	"github.com/cristianoliveira/tmux-intray/internal/settings"
 	"github.com/cristianoliveira/tmux-intray/internal/storage"
+	"github.com/cristianoliveira/tmux-intray/internal/tui/app"
+	"github.com/spf13/cobra"
 )
 
-var fileStorage, _ = storage.NewFromConfig()
-var coreClient = core.NewCore(nil, fileStorage)
+type cliCore interface {
+	EnsureTmuxRunning() bool
+	AddTrayItem(item, session, window, pane, paneCreated string, noAssociate bool, level string) (string, error)
+	ListNotifications(stateFilter, levelFilter, sessionFilter, windowFilter, paneFilter, olderThanCutoff, newerThanCutoff, readFilter string) (string, error)
+	GetActiveCount() int
+	DismissNotification(id string) error
+	DismissAll() error
+	MarkNotificationRead(id string) error
+	MarkNotificationUnread(id string) error
+	CleanupOldNotifications(daysThreshold int, dryRun bool) error
+	JumpToPane(sessionID, windowID, paneID string) bool
+	ValidatePaneExists(sessionID, windowID, paneID string) bool
+	GetNotificationByID(id string) (string, error)
+	GetCurrentTmuxContext() core.TmuxContext
+	GetTmuxVisibility() string
+	SetTmuxVisibility(value string) (bool, error)
+	ClearTrayItems() error
+	LoadSettings() (*settings.Settings, error)
+	ResetSettings() (*settings.Settings, error)
+}
+
+type cliDeps struct {
+	coreClient cliCore
+	storage    ports.NotificationRepository
+	tuiClient  tuiClient
+}
+
+var newStorageFromConfig = storage.NewFromConfig
+
+func buildCLIDeps() (cliDeps, error) {
+	stor, err := newStorageFromConfig()
+	if err != nil {
+		return cliDeps{}, fmt.Errorf("deps: failed to initialize storage: %w", err)
+	}
+	coreClient := core.NewCoreWithDeps(nil, stor, nil)
+	return cliDeps{
+		coreClient: coreClient,
+		storage:    stor,
+		tuiClient:  app.NewDefaultClient(nil),
+	}, nil
+}
+
+var registerCommandsOnce sync.Once
+
+func registerCommands(root *cobra.Command, deps cliDeps) {
+	registerCommandsOnce.Do(func() {
+		root.AddCommand(NewAddCmd(deps.coreClient))
+		root.AddCommand(NewListCmd(deps.coreClient))
+		root.AddCommand(NewStatusCmd(deps.coreClient))
+		root.AddCommand(NewFollowCmd(deps.coreClient))
+		root.AddCommand(NewClearCmd(deps.coreClient))
+		root.AddCommand(NewDismissCmd(deps.coreClient))
+		root.AddCommand(NewMarkReadCmd(deps.coreClient))
+		root.AddCommand(NewCleanupCmd(deps.coreClient))
+		root.AddCommand(NewJumpCmd(deps.coreClient))
+		root.AddCommand(NewSettingsCmd(deps.coreClient))
+		root.AddCommand(NewTUICmd(deps.tuiClient))
+
+		dismissFunc = deps.coreClient.DismissNotification
+		dismissAllFunc = deps.coreClient.DismissAll
+		clearAllFunc = func() error {
+			return deps.coreClient.DismissAll()
+		}
+	})
+}
+
+func initCLI() error {
+	deps, err := buildCLIDeps()
+	if err != nil {
+		return err
+	}
+	registerCommands(cmd.RootCmd, deps)
+	return nil
+}

--- a/cmd/tmux-intray/deps_test.go
+++ b/cmd/tmux-intray/deps_test.go
@@ -1,0 +1,223 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/cristianoliveira/tmux-intray/internal/core"
+	"github.com/cristianoliveira/tmux-intray/internal/settings"
+	"github.com/cristianoliveira/tmux-intray/internal/storage"
+	"github.com/cristianoliveira/tmux-intray/internal/tui/app"
+	"github.com/spf13/cobra"
+)
+
+type fakeStorage struct{}
+
+func (f *fakeStorage) AddNotification(message, timestamp, session, window, pane, paneCreated, level string) (string, error) {
+	return "", nil
+}
+
+func (f *fakeStorage) ListNotifications(stateFilter, levelFilter, sessionFilter, windowFilter, paneFilter, olderThanCutoff, newerThanCutoff, readFilter string) (string, error) {
+	return "", nil
+}
+
+func (f *fakeStorage) GetNotificationByID(id string) (string, error) {
+	return "", nil
+}
+
+func (f *fakeStorage) DismissNotification(id string) error {
+	return nil
+}
+
+func (f *fakeStorage) DismissAll() error {
+	return nil
+}
+
+func (f *fakeStorage) DismissByFilter(session, window, pane string) error {
+	return nil
+}
+
+func (f *fakeStorage) MarkNotificationRead(id string) error {
+	return nil
+}
+
+func (f *fakeStorage) MarkNotificationUnread(id string) error {
+	return nil
+}
+
+func (f *fakeStorage) MarkNotificationReadWithTimestamp(id, timestamp string) error {
+	return nil
+}
+
+func (f *fakeStorage) MarkNotificationUnreadWithTimestamp(id, timestamp string) error {
+	return nil
+}
+
+func (f *fakeStorage) CleanupOldNotifications(daysThreshold int, dryRun bool) error {
+	return nil
+}
+
+func (f *fakeStorage) GetActiveCount() int {
+	return 0
+}
+
+type fakeCore struct{}
+
+func (f *fakeCore) EnsureTmuxRunning() bool {
+	return true
+}
+
+func (f *fakeCore) AddTrayItem(item, session, window, pane, paneCreated string, noAssociate bool, level string) (string, error) {
+	return "", nil
+}
+
+func (f *fakeCore) ListNotifications(stateFilter, levelFilter, sessionFilter, windowFilter, paneFilter, olderThanCutoff, newerThanCutoff, readFilter string) (string, error) {
+	return "", nil
+}
+
+func (f *fakeCore) GetActiveCount() int {
+	return 0
+}
+
+func (f *fakeCore) DismissNotification(id string) error {
+	return nil
+}
+
+func (f *fakeCore) DismissAll() error {
+	return nil
+}
+
+func (f *fakeCore) MarkNotificationRead(id string) error {
+	return nil
+}
+
+func (f *fakeCore) MarkNotificationUnread(id string) error {
+	return nil
+}
+
+func (f *fakeCore) CleanupOldNotifications(daysThreshold int, dryRun bool) error {
+	return nil
+}
+
+func (f *fakeCore) JumpToPane(sessionID, windowID, paneID string) bool {
+	return true
+}
+
+func (f *fakeCore) ValidatePaneExists(sessionID, windowID, paneID string) bool {
+	return true
+}
+
+func (f *fakeCore) GetNotificationByID(id string) (string, error) {
+	return "", nil
+}
+
+func (f *fakeCore) GetCurrentTmuxContext() core.TmuxContext {
+	return core.TmuxContext{}
+}
+
+func (f *fakeCore) GetTmuxVisibility() string {
+	return "0"
+}
+
+func (f *fakeCore) SetTmuxVisibility(value string) (bool, error) {
+	return true, nil
+}
+
+func (f *fakeCore) ClearTrayItems() error {
+	return nil
+}
+
+func (f *fakeCore) LoadSettings() (*settings.Settings, error) {
+	return settings.DefaultSettings(), nil
+}
+
+func (f *fakeCore) ResetSettings() (*settings.Settings, error) {
+	return settings.DefaultSettings(), nil
+}
+
+type fakeTUIClient struct{}
+
+func (f *fakeTUIClient) LoadSettings() (*settings.Settings, error) {
+	return settings.DefaultSettings(), nil
+}
+
+func (f *fakeTUIClient) CreateModel() (app.Model, error) {
+	return nil, errors.New("no model")
+}
+
+func (f *fakeTUIClient) RunProgram(model app.Model) error {
+	return nil
+}
+
+func TestBuildCLIDepsReturnsStorageError(t *testing.T) {
+	originalNewStorage := newStorageFromConfig
+	defer func() { newStorageFromConfig = originalNewStorage }()
+
+	newStorageFromConfig = func() (storage.Storage, error) {
+		return nil, errors.New("storage unavailable")
+	}
+
+	_, err := buildCLIDeps()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if err.Error() == "" {
+		t.Fatal("expected error message, got empty string")
+	}
+}
+
+func TestBuildCLIDepsSuccess(t *testing.T) {
+	originalNewStorage := newStorageFromConfig
+	defer func() { newStorageFromConfig = originalNewStorage }()
+
+	stubStorage := &fakeStorage{}
+	newStorageFromConfig = func() (storage.Storage, error) {
+		return stubStorage, nil
+	}
+
+	deps, err := buildCLIDeps()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if deps.coreClient == nil {
+		t.Fatal("expected coreClient to be set")
+	}
+	if deps.storage != stubStorage {
+		t.Fatal("expected storage to match stub")
+	}
+	if deps.tuiClient == nil {
+		t.Fatal("expected tuiClient to be set")
+	}
+}
+
+func TestRegisterCommandsAddsCommands(t *testing.T) {
+	originalDismissFunc := dismissFunc
+	originalDismissAllFunc := dismissAllFunc
+	originalClearAllFunc := clearAllFunc
+	defer func() {
+		dismissFunc = originalDismissFunc
+		dismissAllFunc = originalDismissAllFunc
+		clearAllFunc = originalClearAllFunc
+	}()
+
+	root := &cobra.Command{Use: "root"}
+	deps := cliDeps{
+		coreClient: &fakeCore{},
+		storage:    &fakeStorage{},
+		tuiClient:  &fakeTUIClient{},
+	}
+
+	registerCommands(root, deps)
+
+	commandNames := map[string]bool{}
+	for _, cmd := range root.Commands() {
+		commandNames[cmd.Name()] = true
+	}
+
+	expected := []string{"add", "list", "status", "follow", "clear", "dismiss", "mark-read", "cleanup", "jump", "settings", "tui"}
+	for _, name := range expected {
+		if !commandNames[name] {
+			t.Fatalf("expected command %q to be registered", name)
+		}
+	}
+}

--- a/cmd/tmux-intray/dismiss.go
+++ b/cmd/tmux-intray/dismiss.go
@@ -9,8 +9,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/cristianoliveira/tmux-intray/cmd"
-
 	"github.com/cristianoliveira/tmux-intray/internal/colors"
 	"github.com/spf13/cobra"
 )
@@ -97,31 +95,26 @@ func dismissSingleNotification(client dismissClient, id string) error {
 	return nil
 }
 
-// dismissCmd represents the dismiss command
-var dismissCmd = NewDismissCmd(coreClient)
+var dismissFunc func(id string) error
 
-var dismissFunc = func(id string) error {
-	return coreClient.DismissNotification(id)
-}
-
-var dismissAllFunc = func() error {
-	return coreClient.DismissAll()
-}
+var dismissAllFunc func() error
 
 var confirmDismissAllFunc = func() bool {
 	return confirmDismissAll()
 }
 
 func Dismiss(id string) error {
+	if dismissFunc == nil {
+		return fmt.Errorf("dismiss: missing dependency")
+	}
 	return dismissFunc(id)
 }
 
 func DismissAll() error {
+	if dismissAllFunc == nil {
+		return fmt.Errorf("dismiss: missing dependency")
+	}
 	return dismissAllFunc()
-}
-
-func init() {
-	cmd.RootCmd.AddCommand(dismissCmd)
 }
 
 // confirmDismissAll asks the user for confirmation before dismissing all notifications.

--- a/cmd/tmux-intray/jump.go
+++ b/cmd/tmux-intray/jump.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cristianoliveira/tmux-intray/cmd"
 	"github.com/cristianoliveira/tmux-intray/internal/colors"
 	"github.com/cristianoliveira/tmux-intray/internal/storage"
 	"github.com/spf13/cobra"
@@ -178,11 +177,4 @@ func reportJumpOutcome(id string, details jumpDetails, paneExists bool) {
 	}
 
 	colors.Warning(fmt.Sprintf("Pane %s no longer exists (jumped to window %s:%s instead)", details.pane, details.session, details.window))
-}
-
-// jumpCmd represents the jump command.
-var jumpCmd = NewJumpCmd(coreClient)
-
-func init() {
-	cmd.RootCmd.AddCommand(jumpCmd)
 }

--- a/cmd/tmux-intray/list_test.go
+++ b/cmd/tmux-intray/list_test.go
@@ -24,23 +24,20 @@ func mockLines() string {
 }
 
 func setupMock() {
-	listListFunc = func(state, level, session, window, pane, olderThan, newerThan, readFilter string) string {
+	listListFunc = func(state, level, session, window, pane, olderThan, newerThan, readFilter string) (string, error) {
 		// We'll apply basic filters here for simplicity.
 		// In real tests we can filter based on parameters.
-		return mockLines()
+		return mockLines(), nil
 	}
 }
 
 func restoreMock() {
-	listListFunc = func(state, level, session, window, pane, olderThan, newerThan, readFilter string) string {
-		// default to real storage (not used in tests)
-		return ""
-	}
+	listListFunc = nil
 }
 
 func TestPrintListEmpty(t *testing.T) {
-	listListFunc = func(state, level, session, window, pane, olderThan, newerThan, readFilter string) string {
-		return ""
+	listListFunc = func(state, level, session, window, pane, olderThan, newerThan, readFilter string) (string, error) {
+		return "", nil
 	}
 	defer restoreMock()
 
@@ -56,8 +53,8 @@ func TestPrintListEmpty(t *testing.T) {
 }
 
 func TestPrintListLegacyFormat(t *testing.T) {
-	listListFunc = func(state, level, session, window, pane, olderThan, newerThan, readFilter string) string {
-		return mockLines()
+	listListFunc = func(state, level, session, window, pane, olderThan, newerThan, readFilter string) (string, error) {
+		return mockLines(), nil
 	}
 	defer restoreMock()
 
@@ -81,8 +78,8 @@ func TestPrintListLegacyFormat(t *testing.T) {
 }
 
 func TestPrintListSimpleFormat(t *testing.T) {
-	listListFunc = func(state, level, session, window, pane, olderThan, newerThan, readFilter string) string {
-		return mockLines()
+	listListFunc = func(state, level, session, window, pane, olderThan, newerThan, readFilter string) (string, error) {
+		return mockLines(), nil
 	}
 	defer restoreMock()
 
@@ -112,8 +109,8 @@ func TestPrintListSimpleFormat(t *testing.T) {
 }
 
 func TestPrintListUnreadFirstOrdering(t *testing.T) {
-	listListFunc = func(state, level, session, window, pane, olderThan, newerThan, readFilter string) string {
-		return mockLines()
+	listListFunc = func(state, level, session, window, pane, olderThan, newerThan, readFilter string) (string, error) {
+		return mockLines(), nil
 	}
 	defer restoreMock()
 
@@ -141,8 +138,8 @@ func TestPrintListUnreadFirstOrdering(t *testing.T) {
 }
 
 func TestPrintListTableFormat(t *testing.T) {
-	listListFunc = func(state, level, session, window, pane, olderThan, newerThan, readFilter string) string {
-		return mockLines()
+	listListFunc = func(state, level, session, window, pane, olderThan, newerThan, readFilter string) (string, error) {
+		return mockLines(), nil
 	}
 	defer restoreMock()
 
@@ -172,8 +169,8 @@ func TestPrintListTableFormat(t *testing.T) {
 }
 
 func TestPrintListCompactFormat(t *testing.T) {
-	listListFunc = func(state, level, session, window, pane, olderThan, newerThan, readFilter string) string {
-		return mockLines()
+	listListFunc = func(state, level, session, window, pane, olderThan, newerThan, readFilter string) (string, error) {
+		return mockLines(), nil
 	}
 	defer restoreMock()
 
@@ -196,8 +193,8 @@ func TestPrintListCompactFormat(t *testing.T) {
 }
 
 func TestPrintListSearchFilter(t *testing.T) {
-	listListFunc = func(state, level, session, window, pane, olderThan, newerThan, readFilter string) string {
-		return mockLines()
+	listListFunc = func(state, level, session, window, pane, olderThan, newerThan, readFilter string) (string, error) {
+		return mockLines(), nil
 	}
 	defer restoreMock()
 
@@ -217,8 +214,8 @@ func TestPrintListSearchFilter(t *testing.T) {
 }
 
 func TestPrintListRegexSearch(t *testing.T) {
-	listListFunc = func(state, level, session, window, pane, olderThan, newerThan, readFilter string) string {
-		return mockLines()
+	listListFunc = func(state, level, session, window, pane, olderThan, newerThan, readFilter string) (string, error) {
+		return mockLines(), nil
 	}
 	defer restoreMock()
 
@@ -245,8 +242,8 @@ func TestPrintListRegexSearch(t *testing.T) {
 }
 
 func TestPrintListGroupByLevelSimple(t *testing.T) {
-	listListFunc = func(state, level, session, window, pane, olderThan, newerThan, readFilter string) string {
-		return mockLines()
+	listListFunc = func(state, level, session, window, pane, olderThan, newerThan, readFilter string) (string, error) {
+		return mockLines(), nil
 	}
 	defer restoreMock()
 
@@ -273,8 +270,8 @@ func TestPrintListGroupByLevelSimple(t *testing.T) {
 }
 
 func TestPrintListGroupByLevel(t *testing.T) {
-	listListFunc = func(state, level, session, window, pane, olderThan, newerThan, readFilter string) string {
-		return mockLines()
+	listListFunc = func(state, level, session, window, pane, olderThan, newerThan, readFilter string) (string, error) {
+		return mockLines(), nil
 	}
 	defer restoreMock()
 
@@ -299,10 +296,10 @@ func TestPrintListGroupByLevel(t *testing.T) {
 func TestPrintListGroupByMessage(t *testing.T) {
 	t.Setenv("TMUX_INTRAY_DEDUP__CRITERIA", "message")
 	t.Setenv("TMUX_INTRAY_DEDUP__WINDOW", "")
-	listListFunc = func(state, level, session, window, pane, olderThan, newerThan, readFilter string) string {
+	listListFunc = func(state, level, session, window, pane, olderThan, newerThan, readFilter string) (string, error) {
 		return "1\t2025-01-01T10:00:00Z\tactive\tsess1\twin1\tpane1\trepeated message\t123\tinfo\t\n" +
 			"2\t2025-01-01T11:00:00Z\tactive\tsess1\twin1\tpane2\trepeated message\t124\twarning\t\n" +
-			"3\t2025-01-01T12:00:00Z\tactive\tsess2\twin2\tpane3\tunique message\t125\terror\t\n"
+			"3\t2025-01-01T12:00:00Z\tactive\tsess2\twin2\tpane3\tunique message\t125\terror\t\n", nil
 	}
 	defer restoreMock()
 
@@ -321,8 +318,8 @@ func TestPrintListGroupByMessage(t *testing.T) {
 }
 
 func TestPrintListGroupCount(t *testing.T) {
-	listListFunc = func(state, level, session, window, pane, olderThan, newerThan, readFilter string) string {
-		return mockLines()
+	listListFunc = func(state, level, session, window, pane, olderThan, newerThan, readFilter string) (string, error) {
+		return mockLines(), nil
 	}
 	defer restoreMock()
 
@@ -349,9 +346,9 @@ func TestPrintListGroupCount(t *testing.T) {
 }
 
 func TestPrintListWithCustomSearchProvider(t *testing.T) {
-	listListFunc = func(state, level, session, window, pane, olderThan, newerThan, readFilter string) string {
+	listListFunc = func(state, level, session, window, pane, olderThan, newerThan, readFilter string) (string, error) {
 		return "1\t2025-01-01T10:00:00Z\tactive\tsess1\twin1\tpane1\terror message\t123\terror\n" +
-			"2\t2025-01-01T11:00:00Z\tactive\tsess1\twin1\tpane2\twarning message\t124\twarning\n"
+			"2\t2025-01-01T11:00:00Z\tactive\tsess1\twin1\tpane2\twarning message\t124\twarning\n", nil
 	}
 	defer restoreMock()
 
@@ -395,8 +392,8 @@ func TestPrintListWithCustomSearchProvider(t *testing.T) {
 func TestPrintListBackwardCompatibility(t *testing.T) {
 	// Verify that existing behavior is preserved when no custom provider is set
 
-	listListFunc = func(state, level, session, window, pane, olderThan, newerThan, readFilter string) string {
-		return "1\t2025-01-01T10:00:00Z\tactive\tsess1\twin1\tpane1\tHello World\t123\tinfo\n"
+	listListFunc = func(state, level, session, window, pane, olderThan, newerThan, readFilter string) (string, error) {
+		return "1\t2025-01-01T10:00:00Z\tactive\tsess1\twin1\tpane1\tHello World\t123\tinfo\n", nil
 	}
 	defer restoreMock()
 
@@ -435,7 +432,7 @@ func TestPrintListBackwardCompatibility(t *testing.T) {
 }
 
 func TestPrintListFilterRead(t *testing.T) {
-	listListFunc = func(state, level, session, window, pane, olderThan, newerThan, readFilter string) string {
+	listListFunc = func(state, level, session, window, pane, olderThan, newerThan, readFilter string) (string, error) {
 		// Only return read notifications (those with non-empty read_timestamp)
 		// Using mockLines which has read timestamps for IDs 1, 3, 5
 		lines := ""
@@ -444,7 +441,7 @@ func TestPrintListFilterRead(t *testing.T) {
 				"3\t2025-01-01T12:00:00Z\tdismissed\tsess2\twin2\tpane3\tmessage three\t125\terror\t2025-01-01T12:05:00Z\n" +
 				"5\t2025-01-01T14:00:00Z\tactive\tsess3\twin3\tpane5\tmessage five\t127\tinfo\t2025-01-01T14:05:00Z"
 		}
-		return lines
+		return lines, nil
 	}
 	defer restoreMock()
 
@@ -477,7 +474,7 @@ func TestPrintListFilterRead(t *testing.T) {
 }
 
 func TestPrintListFilterUnread(t *testing.T) {
-	listListFunc = func(state, level, session, window, pane, olderThan, newerThan, readFilter string) string {
+	listListFunc = func(state, level, session, window, pane, olderThan, newerThan, readFilter string) (string, error) {
 		// Only return unread notifications (those with empty read_timestamp)
 		// Using mockLines which has no read timestamps for IDs 2, 4
 		lines := ""
@@ -485,7 +482,7 @@ func TestPrintListFilterUnread(t *testing.T) {
 			lines = "2\t2025-01-01T11:00:00Z\tactive\tsess1\twin1\tpane2\tmessage two\t124\twarning\t\n" +
 				"4\t2025-01-01T13:00:00Z\tactive\tsess2\twin2\tpane4\tmessage four\t126\tinfo\t"
 		}
-		return lines
+		return lines, nil
 	}
 	defer restoreMock()
 
@@ -703,8 +700,8 @@ func TestPrintFunctionsWithSingleNotification(t *testing.T) {
 }
 
 func TestPrintListJSONFormat(t *testing.T) {
-	listListFunc = func(state, level, session, window, pane, olderThan, newerThan, readFilter string) string {
-		return mockLines()
+	listListFunc = func(state, level, session, window, pane, olderThan, newerThan, readFilter string) (string, error) {
+		return mockLines(), nil
 	}
 	defer restoreMock()
 
@@ -721,8 +718,8 @@ func TestPrintListJSONFormat(t *testing.T) {
 }
 
 func TestPrintListUnknownFormat(t *testing.T) {
-	listListFunc = func(state, level, session, window, pane, olderThan, newerThan, readFilter string) string {
-		return mockLines()
+	listListFunc = func(state, level, session, window, pane, olderThan, newerThan, readFilter string) (string, error) {
+		return mockLines(), nil
 	}
 	defer restoreMock()
 

--- a/cmd/tmux-intray/main.go
+++ b/cmd/tmux-intray/main.go
@@ -8,7 +8,12 @@ import (
 )
 
 func main() {
-	exitCode := run(os.Args[1:], cmd.Execute)
+	exitCode := run(os.Args[1:], func() error {
+		if err := initCLI(); err != nil {
+			return err
+		}
+		return cmd.Execute()
+	})
 	if exitCode != 0 {
 		os.Exit(exitCode)
 	}

--- a/cmd/tmux-intray/mark-read.go
+++ b/cmd/tmux-intray/mark-read.go
@@ -6,8 +6,6 @@ package main
 import (
 	"fmt"
 
-	"github.com/cristianoliveira/tmux-intray/cmd"
-
 	"github.com/cristianoliveira/tmux-intray/internal/colors"
 	"github.com/spf13/cobra"
 )
@@ -45,11 +43,4 @@ OPTIONS:
 	}
 
 	return markReadCmd
-}
-
-// markReadCmd represents the mark-read command
-var markReadCmd = NewMarkReadCmd(coreClient)
-
-func init() {
-	cmd.RootCmd.AddCommand(markReadCmd)
 }

--- a/cmd/tmux-intray/settings.go
+++ b/cmd/tmux-intray/settings.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/cristianoliveira/tmux-intray/cmd"
 	"github.com/cristianoliveira/tmux-intray/internal/colors"
 	"github.com/cristianoliveira/tmux-intray/internal/settings"
 	"github.com/spf13/cobra"
@@ -151,13 +150,6 @@ func runShowCmd(client settingsClient) error {
 	// Display settings
 	colors.Info(string(data))
 	return nil
-}
-
-// settingsCmd represents the settings command
-var settingsCmd = NewSettingsCmd(coreClient)
-
-func init() {
-	cmd.RootCmd.AddCommand(settingsCmd)
 }
 
 // confirmReset asks the user for confirmation before resetting settings.

--- a/cmd/tmux-intray/status.go
+++ b/cmd/tmux-intray/status.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/cristianoliveira/tmux-intray/cmd"
 	"github.com/cristianoliveira/tmux-intray/internal/domain"
 	"github.com/cristianoliveira/tmux-intray/internal/format"
 	"github.com/cristianoliveira/tmux-intray/internal/formatter"
@@ -200,13 +199,6 @@ func buildVariableContext(client statusClient) formatter.VariableContext {
 		WindowList:      "",
 		PaneList:        "",
 	}
-}
-
-// statusCmd represents the status command.
-var statusCmd = NewStatusCmd(coreClient)
-
-func init() {
-	cmd.RootCmd.AddCommand(statusCmd)
 }
 
 // Helper functions

--- a/cmd/tmux-intray/tui.go
+++ b/cmd/tmux-intray/tui.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/cristianoliveira/tmux-intray/cmd"
 	"github.com/cristianoliveira/tmux-intray/internal/colors"
 	"github.com/cristianoliveira/tmux-intray/internal/settings"
 	"github.com/cristianoliveira/tmux-intray/internal/tui/app"
@@ -77,11 +76,4 @@ USAGE:
 			return client.RunProgram(model)
 		},
 	}
-}
-
-// tuiCmd represents the tui command
-var tuiCmd = NewTUICmd(app.NewDefaultClient(nil))
-
-func init() {
-	cmd.RootCmd.AddCommand(tuiCmd)
 }


### PR DESCRIPTION
## Summary
- Decouple the CLI composition root to simplify wiring and improve module boundaries.
- Refactor follow tick handling to make the flow clearer and reduce implicit dependencies.

## Testing
- Not run (not requested).