### PR TITLE
fix(tui): grouped slash search and Enter navigation

### DIFF
--- a/internal/tui/render/render.go
+++ b/internal/tui/render/render.go
@@ -169,14 +169,7 @@ func buildFullHelpSearchModeItems(state FooterState) []string {
 	items = append(items, "R: read")
 	items = append(items, "u: unread")
 	items = append(items, "d: dismiss")
-	enterHelp := "Enter: exit search"
-	if state.ViewMode == settings.ViewModeSearch {
-		enterHelp = "Enter: jump"
-		if state.Grouped {
-			enterHelp = "Enter: toggle/jump"
-		}
-	}
-	items = append(items, enterHelp)
+	items = append(items, "Enter: jump")
 	items = append(items, "q: quit")
 	items = append(items, "?: toggle help")
 	return items
@@ -192,7 +185,7 @@ func buildFullHelpNormalModeItems(state FooterState) []string {
 	items = append(items, fmt.Sprintf("read: %s", readFilterIndicator(state.ReadFilter)))
 	items = append(items, "j/k: move")
 	items = append(items, "gg/G: top/bottom")
-	items = append(items, "/: search view")
+	items = append(items, "/: search messages")
 	items = append(items, "v: cycle view mode")
 	if state.Grouped {
 		items = append(items, "h/l: collapse/expand")

--- a/internal/tui/render/render_test.go
+++ b/internal/tui/render/render_test.go
@@ -257,7 +257,7 @@ func TestFooterGroupedHelpText(t *testing.T) {
 	assert.Contains(t, footer, "a: all")
 	assert.Contains(t, footer, "R: read")
 	assert.Contains(t, footer, "Enter: toggle/jump")
-	assert.Contains(t, footer, "/: search view")
+	assert.Contains(t, footer, "/: search messages")
 	assert.NotContains(t, footer, "Ctrl+f")
 }
 
@@ -269,6 +269,8 @@ func TestFooterSearchModeHelpText(t *testing.T) {
 	assert.Contains(t, footer, "read: all")
 	assert.Contains(t, footer, "ESC: exit search")
 	assert.Contains(t, footer, "Ctrl+j/k: navigate")
+	assert.Contains(t, footer, "Enter: jump")
+	assert.NotContains(t, footer, "Enter: exit search")
 	assert.Contains(t, footer, "Search: test")
 }
 
@@ -283,10 +285,10 @@ func TestFooterSearchViewModeHelpTextShowsJumpOnEnter(t *testing.T) {
 	assert.NotContains(t, footer, "Enter: exit search")
 }
 
-func TestFooterSearchViewModeHelpTextShowsToggleJumpWhenGrouped(t *testing.T) {
+func TestFooterSearchViewModeHelpTextShowsJumpWhenGrouped(t *testing.T) {
 	footer := Footer(FooterState{SearchMode: true, SearchQuery: "test", Grouped: true, ViewMode: settings.ViewModeSearch, ShowHelp: true})
 
-	assert.Contains(t, footer, "Enter: toggle/jump")
+	assert.Contains(t, footer, "Enter: jump")
 }
 
 func TestFooterSearchModeWithoutHelp(t *testing.T) {

--- a/internal/tui/state/model_key_handlers.go
+++ b/internal/tui/state/model_key_handlers.go
@@ -5,7 +5,6 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/cristianoliveira/tmux-intray/internal/settings"
-	"github.com/cristianoliveira/tmux-intray/internal/tui/model"
 )
 
 // handleCtrlC handles Ctrl+C to exit the TUI.
@@ -32,15 +31,7 @@ func (m *Model) handleEsc() (tea.Model, tea.Cmd) {
 // handleEnter handles Enter to confirm search or jump to pane.
 func (m *Model) handleEnter() (tea.Model, tea.Cmd) {
 	if m.uiState.IsSearchMode() {
-		// In search view mode, Enter should immediately perform jump.
-		if m.uiState.GetViewMode() == model.ViewModeSearch {
-			return m, m.handleJump()
-		}
-		// In other view modes, Enter confirms/exits search input.
-		m.uiState.SetSearchMode(false)
-		m.applySearchFilter()
-		m.uiState.ResetCursor()
-		return m, nil
+		return m, m.handleJump()
 	}
 	if m.isGroupedView() && m.toggleNodeExpansion() {
 		return m, nil

--- a/internal/tui/state/model_keys_core.go
+++ b/internal/tui/state/model_keys_core.go
@@ -221,9 +221,7 @@ func (m *Model) handleMarkKeys(key string) (tea.Model, tea.Cmd) {
 func (m *Model) handleModeKeys(key string, allowInSearch bool) (tea.Model, tea.Cmd) {
 	switch key {
 	case "/":
-		viewModeBeforeSearch := m.uiState.GetViewMode()
-		m.handleSearchViewMode()
-		m.uiState.SetViewMode(viewModeBeforeSearch)
+		m.handleSearchMode()
 		return m, nil
 	case "?":
 		m.uiState.SetShowHelp(!m.uiState.ShowHelp())

--- a/internal/tui/state/model_test.go
+++ b/internal/tui/state/model_test.go
@@ -1058,6 +1058,38 @@ func TestModelUpdateHandlesSearch(t *testing.T) {
 	assert.Len(t, model.filtered, 3)
 }
 
+func TestModelUpdateSlashInGroupedViewKeepsGroupedModeAndFilters(t *testing.T) {
+	setupConfig(t, t.TempDir())
+
+	model := newTestModel(t, []notification.Notification{
+		{ID: 1, Session: "$1", Window: "@1", Pane: "%1", Message: "foo message"},
+		{ID: 2, Session: "$1", Window: "@2", Pane: "%1", Message: "bar message"},
+	})
+	model.uiState.SetWidth(80)
+	model.uiState.GetViewport().Width = 80
+	model.uiState.SetViewMode(settings.ViewModeGrouped)
+	model.applySearchFilter()
+	model.resetCursor()
+
+	updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	model = updated.(*Model)
+
+	assert.True(t, model.uiState.IsSearchMode())
+	assert.Equal(t, settings.ViewModeGrouped, string(model.uiState.GetViewMode()))
+
+	loaded, err := settings.Load()
+	require.NoError(t, err)
+	assert.Equal(t, settings.ViewModeGrouped, loaded.ViewMode)
+
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	model = updated.(*Model)
+
+	assert.Equal(t, settings.ViewModeGrouped, string(model.uiState.GetViewMode()))
+	assert.Equal(t, "f", model.uiState.GetSearchQuery())
+	assert.Len(t, model.filtered, 1)
+	assert.Equal(t, "foo message", model.filtered[0].Message)
+}
+
 func TestModelUpdateSearchViewModeEnterJumpsWhileSearchActive(t *testing.T) {
 	setupStorage(t)
 
@@ -1455,9 +1487,35 @@ func TestModelUpdateHandlesSearchEnter(t *testing.T) {
 	model = updated.(*Model)
 
 	assert.Nil(t, cmd)
-	assert.False(t, model.uiState.IsSearchMode())
-	// In the new implementation, search query is cleared when exiting search mode
-	assert.Equal(t, "", model.uiState.GetSearchQuery())
+	assert.True(t, model.uiState.IsSearchMode())
+	assert.Equal(t, "test query", model.uiState.GetSearchQuery())
+}
+
+func TestModelUpdateGroupedSearchEnterJumps(t *testing.T) {
+	setupStorage(t)
+
+	model := newTestModelWithOptions(t, []notification.Notification{
+		{ID: 1, Message: "jump me", Session: "$1", Window: "@1", Pane: "%1"},
+	}, func(m *Model) {
+		m.runtimeCoordinator = &testRuntimeCoordinator{
+			ensureTmuxRunningFn: func() bool { return true },
+			jumpToPaneFn:        func(sessionID, windowID, paneID string) bool { return true },
+		}
+	})
+	model.uiState.SetWidth(80)
+	model.uiState.GetViewport().Width = 80
+	model.uiState.SetViewMode(settings.ViewModeGrouped)
+	model.uiState.SetSearchMode(true)
+	model.uiState.SetSearchQuery("jump")
+	model.applySearchFilter()
+	model.resetCursor()
+
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(*Model)
+
+	assert.NotNil(t, cmd)
+	assert.True(t, model.uiState.IsSearchMode())
+	assert.Equal(t, settings.ViewModeGrouped, string(model.uiState.GetViewMode()))
 }
 
 // TestCtrlJKNavigationInSearchMode tests that Ctrl+j and Ctrl+k work for navigation in search mode.
@@ -1932,7 +1990,7 @@ func TestModelViewRendersContent(t *testing.T) {
 	assert.Contains(t, view, "AGE")
 	assert.Contains(t, view, "Test notification")
 	assert.Contains(t, view, "j/k: move")
-	assert.Contains(t, view, "/: search view")
+	assert.Contains(t, view, "/: search messages")
 	assert.NotContains(t, view, "Ctrl+f")
 	assert.Contains(t, view, "q: quit")
 }


### PR DESCRIPTION
Keeps grouped mode on slash search in grouped view, makes Enter in search mode jump to selected result, updates footer/help text, and adds tests for grouped slash filtering plus search Enter behavior.