### PR TITLE
refactor: duplicate add validation by centralizing message checks

### DIFF
--- a/cmd/tmux-intray/add.go
+++ b/cmd/tmux-intray/add.go
@@ -48,13 +48,6 @@ OPTIONS:
 
 If no pane association options are provided, automatically associates with
 the current tmux pane (if inside tmux). Use --no-associate to skip.`,
-		Args: func(cmd *cobra.Command, args []string) error {
-			if len(args) == 0 {
-				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "add requires a message\n")
-				return fmt.Errorf("")
-			}
-			return nil
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runAddCmd(client, args, sessionFlag, windowFlag, paneFlag, paneCreatedFlag, noAssociateFlag, levelFlag)
 		},

--- a/cmd/tmux-intray/add_test.go
+++ b/cmd/tmux-intray/add_test.go
@@ -14,9 +14,8 @@ func TestAddCmdArgsValidation(t *testing.T) {
 		name    string
 		args    []string
 		wantErr bool
-		wantMsg string
 	}{
-		{name: "no args returns error", args: []string{}, wantErr: true, wantMsg: "add requires a message"},
+		{name: "no args returns no error", args: []string{}, wantErr: false},
 		{name: "one arg returns no error", args: []string{"hello"}, wantErr: false},
 		{name: "multiple args returns no error", args: []string{"hello", "world"}, wantErr: false},
 	}
@@ -30,8 +29,8 @@ func TestAddCmdArgsValidation(t *testing.T) {
 			if !tt.wantErr && err != nil {
 				t.Fatalf("expected no error, got %v", err)
 			}
-			if tt.wantMsg != "" && !strings.Contains(stderr, tt.wantMsg) {
-				t.Fatalf("expected stderr to contain %q, got %q", tt.wantMsg, stderr)
+			if stderr != "" {
+				t.Fatalf("expected no stderr output, got %q", stderr)
 			}
 		})
 	}
@@ -49,10 +48,23 @@ func TestAddCmdArgsNilAndEmptySlicesAreStable(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := runAddArgsSafely(t, tt.args)
-			if err == nil {
-				t.Fatalf("expected error for %s, got nil", tt.name)
+			if err != nil {
+				t.Fatalf("expected no error for %s, got %v", tt.name, err)
 			}
 		})
+	}
+}
+
+func TestAddRunENoArgsUsesCentralizedMessageValidation(t *testing.T) {
+	client := &fakeAddClient{ensureTmuxRunningResult: true}
+	add := NewAddCmd(client)
+
+	err := add.RunE(add, []string{})
+	if err == nil || !strings.Contains(err.Error(), "message cannot be empty") {
+		t.Fatalf("expected message validation error, got %v", err)
+	}
+	if client.addCalled {
+		t.Fatalf("expected AddTrayItem not to be called")
 	}
 }
 
@@ -89,7 +101,7 @@ func runAddArgsSafely(t *testing.T, args []string) (string, error) {
 		}
 	}()
 
-	err := add.Args(add, args)
+	err := add.ValidateArgs(args)
 	return errBuffer.String(), err
 }
 

--- a/tests/cli.bats
+++ b/tests/cli.bats
@@ -20,7 +20,7 @@
 
     run ./tmux-intray add
     [ "$status" -eq 1 ]
-    [[ "$output" == *"requires a message"* ]]
+    [[ "$output" == *"message cannot be empty"* ]]
 }
 
 @test "commands work when invoked from different working directory" {

--- a/tests/commands/add.bats
+++ b/tests/commands/add.bats
@@ -17,7 +17,7 @@ teardown() {
 @test "add requires a message" {
     run ./tmux-intray add
     [ "$status" -eq 1 ]
-    [[ "$output" == *"requires a message"* ]]
+    [[ "$output" == *"message cannot be empty"* ]]
 }
 
 @test "add item to tray" {


### PR DESCRIPTION
## Summary
- remove duplicate add message validation from Cobra Args and centralize validation in runAddCmd via validateMessage
- align command and CLI tests with the centralized error path (message cannot be empty)
- keep behavior consistent while reducing validation drift in add flow

## Validation
- make go-build
- make tests
- env TMUX_INTRAY_BIN=/Users/cristianoliveira/other/tmux-intray/.gwt/bdev/tmux-intray ./scripts/verify-binary.sh

Closes #332