### PR TITLE
feat(telemetry): add telemetry CLI with show, export, clear, and status commands

### DIFF
--- a/cmd/tmux-intray/deps.go
+++ b/cmd/tmux-intray/deps.go
@@ -35,9 +35,10 @@ type cliCore interface {
 }
 
 type cliDeps struct {
-	coreClient cliCore
-	storage    ports.NotificationRepository
-	tuiClient  tuiClient
+	coreClient       cliCore
+	storage          ports.NotificationRepository
+	telemetryStorage ports.TelemetryStorage
+	tuiClient        tuiClient
 }
 
 type storageFactory func() (ports.NotificationRepository, error)
@@ -86,10 +87,18 @@ func buildCLIDepsWithFactories(factories cliDepsFactories) (cliDeps, error) {
 		return cliDeps{}, fmt.Errorf("deps: failed to initialize tui: %w", err)
 	}
 
+	// Try to get TelemetryStorage interface from the storage implementation
+	// The SQLiteStorage implements both NotificationRepository and TelemetryStorage
+	var telemetryStorage TelemetryStorage
+	if ts, ok := stor.(TelemetryStorage); ok {
+		telemetryStorage = ts
+	}
+
 	return cliDeps{
-		coreClient: coreClient,
-		storage:    stor,
-		tuiClient:  tuiClient,
+		coreClient:       coreClient,
+		storage:          stor,
+		telemetryStorage: telemetryStorage,
+		tuiClient:        tuiClient,
 	}, nil
 }
 
@@ -108,6 +117,9 @@ func registerCommands(root *cobra.Command, deps cliDeps) {
 		root.AddCommand(NewJumpCmd(deps.coreClient))
 		root.AddCommand(NewSettingsCmd(deps.coreClient))
 		root.AddCommand(NewTUICmd(deps.tuiClient))
+		if deps.telemetryStorage != nil {
+			root.AddCommand(NewTelemetryCmd(deps.telemetryStorage, &telemetryConfigAdapter{}))
+		}
 
 		dismissFunc = deps.coreClient.DismissNotification
 		dismissAllFunc = deps.coreClient.DismissAll

--- a/cmd/tmux-intray/telemetry.go
+++ b/cmd/tmux-intray/telemetry.go
@@ -1,0 +1,459 @@
+/*
+Copyright © 2026 Cristian Oliveira <license@cristianoliveira.dev>
+*/
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/cristianoliveira/tmux-intray/internal/colors"
+	"github.com/cristianoliveira/tmux-intray/internal/config"
+	"github.com/cristianoliveira/tmux-intray/internal/ports"
+	"github.com/spf13/cobra"
+)
+
+const checkmark = "✓"
+
+// TelemetryStorage is an alias to the ports interface.
+type TelemetryStorage = ports.TelemetryStorage
+
+// TelemetryStatus represents the current status of telemetry.
+type TelemetryStatus struct {
+	Enabled      bool
+	TotalEvents  int64
+	FirstEvent   string
+	LastEvent    string
+	DatabaseSize int64
+}
+
+type telemetryClient struct {
+	storage TelemetryStorage
+	config  TelemetryConfig
+}
+
+// TelemetryConfig defines the interface for checking telemetry configuration.
+type TelemetryConfig interface {
+	IsEnabled() bool
+}
+
+// NewTelemetryCmd creates the telemetry command with explicit dependencies.
+func NewTelemetryCmd(storage TelemetryStorage, config TelemetryConfig) *cobra.Command {
+	if storage == nil {
+		panic("NewTelemetryCmd: storage dependency cannot be nil")
+	}
+	if config == nil {
+		panic("NewTelemetryCmd: config dependency cannot be nil")
+	}
+
+	client := &telemetryClient{
+		storage: storage,
+		config:  config,
+	}
+
+	const telemetryCommandLong = `Manage telemetry data and settings.
+
+USAGE:
+    tmux-intray telemetry <subcommand>
+
+SUBCOMMANDS:
+    show      Display feature usage summary
+    export    Export telemetry data to JSONL format
+    clear     Clear old telemetry data
+    status    Show telemetry status
+
+PRIVACY:
+    Data is local-only and never transmitted`
+
+	telemetryCmd := &cobra.Command{
+		Use:   "telemetry",
+		Short: "Manage telemetry data and settings",
+		Long:  telemetryCommandLong,
+	}
+
+	showCmd := newShowTelemetryCmd(client)
+	exportCmd := newExportCmd(client)
+	clearCmd := newClearTelemetryCmd(client)
+	statusCmd := newStatusTelemetryCmd(client)
+
+	telemetryCmd.AddCommand(showCmd)
+	telemetryCmd.AddCommand(exportCmd)
+	telemetryCmd.AddCommand(clearCmd)
+	telemetryCmd.AddCommand(statusCmd)
+
+	return telemetryCmd
+}
+
+// newShowTelemetryCmd creates the show subcommand.
+func newShowTelemetryCmd(client *telemetryClient) *cobra.Command {
+	var showDays int
+
+	showCmd := &cobra.Command{
+		Use:   "show [--days N]",
+		Short: "Display feature usage summary",
+		Long: `Display feature usage summary grouped by feature name and category.
+
+USAGE:
+    tmux-intray telemetry show [--days N]
+
+OPTIONS:
+    --days N    Show usage from the last N days (default: all time)
+
+PRIVACY:
+    Data is local-only and never transmitted`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runShowTelemetryCmd(cmd, client, showDays)
+		},
+	}
+	showCmd.Flags().IntVar(&showDays, "days", 0, "Show usage from the last N days (default: all time)")
+
+	return showCmd
+}
+
+// runShowTelemetryCmd executes the show subcommand.
+func runShowTelemetryCmd(cmd *cobra.Command, client *telemetryClient, days int) error {
+	out := cmd.OutOrStdout()
+	errOut := cmd.ErrOrStderr()
+
+	if !client.config.IsEnabled() {
+		_, _ = fmt.Fprintln(out, colors.Blue, "Telemetry is currently disabled", colors.Reset)
+		_, _ = fmt.Fprintln(errOut, colors.Yellow, "Warning:", colors.Reset, "Data is local-only and never transmitted")
+		return nil
+	}
+
+	// Get all features with usage stats
+	features, err := client.storage.GetAllFeatures()
+	if err != nil {
+		return fmt.Errorf("telemetry show: failed to get feature usage: %w", err)
+	}
+
+	if len(features) == 0 {
+		_, _ = fmt.Fprintln(out, colors.Blue, "No telemetry data available", colors.Reset)
+		_, _ = fmt.Fprintln(errOut, colors.Yellow, "Warning:", colors.Reset, "Data is local-only and never transmitted")
+		return nil
+	}
+
+	// Filter by days if specified
+	if days > 0 {
+		features, err = filterFeaturesByDays(client, features, days)
+		if err != nil {
+			return fmt.Errorf("telemetry show: failed to filter by days: %w", err)
+		}
+		if len(features) == 0 {
+			_, _ = fmt.Fprintln(out, colors.Blue, "No telemetry data available in the specified time range", colors.Reset)
+			_, _ = fmt.Fprintln(errOut, colors.Yellow, "Warning:", colors.Reset, "Data is local-only and never transmitted")
+			return nil
+		}
+	}
+
+	// Group by category
+	categoryMap := make(map[string][]ports.FeatureUsage)
+	for _, feature := range features {
+		categoryMap[feature.FeatureCategory] = append(categoryMap[feature.FeatureCategory], feature)
+	}
+
+	// Sort categories alphabetically
+	categories := make([]string, 0, len(categoryMap))
+	for category := range categoryMap {
+		categories = append(categories, category)
+	}
+	sort.Strings(categories)
+
+	// Display results
+	_, _ = fmt.Fprintln(out)
+	for _, category := range categories {
+		_, _ = fmt.Fprintf(out, "%sCategory: %s%s\n", colors.Yellow, category, colors.Reset)
+		categoryFeatures := categoryMap[category]
+		// Sort by usage count (descending)
+		sort.Slice(categoryFeatures, func(i, j int) bool {
+			return categoryFeatures[i].UsageCount > categoryFeatures[j].UsageCount
+		})
+		for _, feature := range categoryFeatures {
+			_, _ = fmt.Fprintf(out, "  %s: %d calls\n", feature.FeatureName, feature.UsageCount)
+		}
+		_, _ = fmt.Fprintln(out)
+	}
+	_, _ = fmt.Fprintln(errOut, colors.Yellow, "Warning:", colors.Reset, "Data is local-only and never transmitted")
+
+	return nil
+}
+
+// filterFeaturesByDays filters features to only include those with usage in the specified time range.
+func filterFeaturesByDays(client *telemetryClient, features []ports.FeatureUsage, days int) ([]ports.FeatureUsage, error) {
+	startTime := time.Now().UTC().AddDate(0, 0, -days).Format("2006-01-02T15:04:05Z")
+
+	// Get events in the time range
+	events, err := client.storage.GetTelemetryEvents(startTime, "")
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a set of feature names that have events in the time range
+	featureSet := make(map[string]bool)
+	for _, event := range events {
+		featureSet[event.FeatureName] = true
+	}
+
+	// Filter features
+	var filtered []ports.FeatureUsage
+	for _, feature := range features {
+		if featureSet[feature.FeatureName] {
+			filtered = append(filtered, feature)
+		}
+	}
+
+	return filtered, nil
+}
+
+// newExportCmd creates the export subcommand.
+func newExportCmd(client *telemetryClient) *cobra.Command {
+	var exportOutput string
+
+	exportCmd := &cobra.Command{
+		Use:   "export --output FILE",
+		Short: "Export telemetry data to JSONL format",
+		Long: `Export telemetry data to JSONL format (one JSON object per line).
+
+USAGE:
+    tmux-intray telemetry export --output FILE
+
+OPTIONS:
+    --output FILE    Output file path (required)
+
+PRIVACY:
+    Data is local-only and never transmitted`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runExportCmd(cmd, client, exportOutput)
+		},
+	}
+	exportCmd.Flags().StringVar(&exportOutput, "output", "", "Output file path (required)")
+	_ = exportCmd.MarkFlagRequired("output")
+
+	return exportCmd
+}
+
+// runExportCmd executes the export subcommand.
+func runExportCmd(cmd *cobra.Command, client *telemetryClient, outputPath string) error {
+	out := cmd.OutOrStdout()
+	errOut := cmd.ErrOrStderr()
+
+	if !client.config.IsEnabled() {
+		_, _ = fmt.Fprintln(out, colors.Blue, "Telemetry is currently disabled", colors.Reset)
+		_, _ = fmt.Fprintln(errOut, colors.Yellow, "Warning:", colors.Reset, "Data is local-only and never transmitted")
+		return nil
+	}
+
+	// Get all events
+	events, err := client.storage.GetTelemetryEvents("", "")
+	if err != nil {
+		return fmt.Errorf("telemetry export: failed to get telemetry events: %w", err)
+	}
+
+	if len(events) == 0 {
+		_, _ = fmt.Fprintln(out, colors.Blue, "No telemetry data to export", colors.Reset)
+		_, _ = fmt.Fprintln(errOut, colors.Yellow, "Warning:", colors.Reset, "Data is local-only and never transmitted")
+		return nil
+	}
+
+	// Create output file
+	file, err := os.Create(outputPath)
+	if err != nil {
+		return fmt.Errorf("telemetry export: failed to create output file: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	writer := bufio.NewWriter(file)
+	defer func() { _ = writer.Flush() }()
+
+	// Write each event as a JSON line
+	for _, event := range events {
+		line, err := json.Marshal(event)
+		if err != nil {
+			return fmt.Errorf("telemetry export: failed to marshal event: %w", err)
+		}
+		if _, err := writer.Write(append(line, '\n')); err != nil {
+			return fmt.Errorf("telemetry export: failed to write event: %w", err)
+		}
+	}
+
+	_, _ = fmt.Fprintf(out, "%s%s %s%s%s\n", colors.Green, checkmark, colors.Reset, fmt.Sprintf("Exported %d telemetry events to %s", len(events), outputPath), colors.Reset)
+	_, _ = fmt.Fprintln(errOut, colors.Yellow, "Warning:", colors.Reset, "Data is local-only and never transmitted")
+
+	return nil
+}
+
+// newClearTelemetryCmd creates the clear subcommand.
+func newClearTelemetryCmd(client *telemetryClient) *cobra.Command {
+	var clearDays int
+
+	clearCmd := &cobra.Command{
+		Use:   "clear [--days N]",
+		Short: "Clear old telemetry data",
+		Long: `Clear telemetry data older than N days.
+
+USAGE:
+    tmux-intray telemetry clear [--days N]
+
+OPTIONS:
+    --days N    Clear events older than N days (default: 90)
+
+PRIVACY:
+    Data is local-only and never transmitted`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runClearTelemetryCmd(cmd, client, clearDays)
+		},
+	}
+	clearCmd.Flags().IntVar(&clearDays, "days", 90, "Clear events older than N days (default: 90)")
+
+	return clearCmd
+}
+
+// runClearTelemetryCmd executes the clear subcommand.
+func runClearTelemetryCmd(cmd *cobra.Command, client *telemetryClient, days int) error {
+	out := cmd.OutOrStdout()
+	errOut := cmd.ErrOrStderr()
+
+	if !client.config.IsEnabled() {
+		_, _ = fmt.Fprintln(out, colors.Blue, "Telemetry is currently disabled", colors.Reset)
+		_, _ = fmt.Fprintln(errOut, colors.Yellow, "Warning:", colors.Reset, "Data is local-only and never transmitted")
+		return nil
+	}
+
+	// If --days is 0, we need to confirm clearing all data
+	if days == 0 {
+		// Skip confirmation in CI/test environment
+		if !allowTmuxlessMode() {
+			if !confirmClearTelemetry() {
+				_, _ = fmt.Fprintln(out, colors.Blue, "Operation cancelled", colors.Reset)
+				return nil
+			}
+		}
+	}
+
+	// Clear telemetry events
+	deleted, err := client.storage.ClearTelemetryEvents(days)
+	if err != nil {
+		return fmt.Errorf("telemetry clear: failed to clear telemetry events: %w", err)
+	}
+
+	if deleted == 0 {
+		_, _ = fmt.Fprintln(out, colors.Blue, "No telemetry data to clear", colors.Reset)
+	} else {
+		_, _ = fmt.Fprintf(out, "%s%s %s%s%s\n", colors.Green, checkmark, colors.Reset, fmt.Sprintf("Cleared %d telemetry event(s)", deleted), colors.Reset)
+	}
+	_, _ = fmt.Fprintln(errOut, colors.Yellow, "Warning:", colors.Reset, "Data is local-only and never transmitted")
+
+	return nil
+}
+
+// confirmClearTelemetry asks the user for confirmation before clearing telemetry data.
+func confirmClearTelemetry() bool {
+	reader := bufio.NewReader(os.Stdin)
+	fmt.Print("Are you sure you want to clear all telemetry data? (y/N): ")
+	answer, err := reader.ReadString('\n')
+	if err != nil {
+		// If we can't read, assume no
+		return false
+	}
+	answer = strings.TrimSpace(strings.ToLower(answer))
+	return answer == "y" || answer == "yes"
+}
+
+// newStatusTelemetryCmd creates the status subcommand.
+func newStatusTelemetryCmd(client *telemetryClient) *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show telemetry status",
+		Long: `Show telemetry status including enabled/disabled state, total events, timestamps, and database size.
+
+USAGE:
+    tmux-intray telemetry status
+
+PRIVACY:
+    Data is local-only and never transmitted`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runStatusTelemetryCmd(cmd, client)
+		},
+	}
+}
+
+// runStatusTelemetryCmd executes the status subcommand.
+func runStatusTelemetryCmd(cmd *cobra.Command, client *telemetryClient) error {
+	out := cmd.OutOrStdout()
+	errOut := cmd.ErrOrStderr()
+
+	status, err := getTelemetryStatus(client)
+	if err != nil {
+		return fmt.Errorf("telemetry status: failed to get status: %w", err)
+	}
+
+	// Display status
+	_, _ = fmt.Fprintln(out)
+	_, _ = fmt.Fprintln(out, "Telemetry Status")
+	_, _ = fmt.Fprintln(out, "------------------")
+	_, _ = fmt.Fprintf(out, "Enabled: %s\n", formatBool(status.Enabled))
+	_, _ = fmt.Fprintf(out, "Total Events: %d\n", status.TotalEvents)
+	if status.TotalEvents > 0 {
+		_, _ = fmt.Fprintf(out, "First Event: %s\n", status.FirstEvent)
+		_, _ = fmt.Fprintf(out, "Last Event: %s\n", status.LastEvent)
+	}
+	if status.DatabaseSize > 0 {
+		_, _ = fmt.Fprintf(out, "Database Size: %d bytes\n", status.DatabaseSize)
+	}
+	_, _ = fmt.Fprintln(out)
+	_, _ = fmt.Fprintln(errOut, colors.Yellow, "Warning:", colors.Reset, "Data is local-only and never transmitted")
+
+	return nil
+}
+
+// getTelemetryStatus retrieves the current telemetry status.
+func getTelemetryStatus(client *telemetryClient) (*TelemetryStatus, error) {
+	status := &TelemetryStatus{
+		Enabled: client.config.IsEnabled(),
+	}
+
+	if !status.Enabled {
+		return status, nil
+	}
+
+	// Get all events to count and find timestamps
+	events, err := client.storage.GetTelemetryEvents("", "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get telemetry events: %w", err)
+	}
+
+	status.TotalEvents = int64(len(events))
+
+	if len(events) > 0 {
+		// Find first and last events
+		// Events are returned in timestamp order
+		status.FirstEvent = events[0].Timestamp
+		status.LastEvent = events[len(events)-1].Timestamp
+	}
+
+	// Get database size (simplified - in a real implementation, we'd query the file size)
+	status.DatabaseSize = 0 // Placeholder for now
+
+	return status, nil
+}
+
+// formatBool returns a colored string representation of a boolean.
+func formatBool(b bool) string {
+	if b {
+		return fmt.Sprintf("%strue%s", colors.Green, colors.Reset)
+	}
+	return fmt.Sprintf("%sfalse%s", colors.Red, colors.Reset)
+}
+
+// telemetryConfigAdapter adapts the config package to TelemetryConfig interface.
+type telemetryConfigAdapter struct{}
+
+func (t *telemetryConfigAdapter) IsEnabled() bool {
+	config.Load()
+	return config.GetBool("telemetry_enabled", false)
+}

--- a/cmd/tmux-intray/telemetry_test.go
+++ b/cmd/tmux-intray/telemetry_test.go
@@ -1,0 +1,497 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cristianoliveira/tmux-intray/internal/storage/sqlite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeTelemetryStorage struct {
+	features      []sqlite.FeatureUsage
+	events        []sqlite.TelemetryEventType
+	deletedCount  int64
+	deleteErr     error
+	getFeatureErr error
+	getAllErr     error
+	getEventsErr  error
+}
+
+func (f *fakeTelemetryStorage) GetFeatureUsage(featureName string) (int64, error) {
+	if f.getFeatureErr != nil {
+		return 0, f.getFeatureErr
+	}
+	for _, feature := range f.features {
+		if feature.FeatureName == featureName {
+			return feature.UsageCount, nil
+		}
+	}
+	return 0, nil
+}
+
+func (f *fakeTelemetryStorage) GetAllFeatures() ([]sqlite.FeatureUsage, error) {
+	if f.getAllErr != nil {
+		return nil, f.getAllErr
+	}
+	return f.features, nil
+}
+
+func (f *fakeTelemetryStorage) GetTelemetryEvents(startTime, endTime string) ([]sqlite.TelemetryEventType, error) {
+	if f.getEventsErr != nil {
+		return nil, f.getEventsErr
+	}
+	// Filter by time range if specified
+	var filtered []sqlite.TelemetryEventType
+	for _, event := range f.events {
+		include := true
+		if startTime != "" && event.Timestamp < startTime {
+			include = false
+		}
+		if endTime != "" && event.Timestamp > endTime {
+			include = false
+		}
+		if include {
+			filtered = append(filtered, event)
+		}
+	}
+	return filtered, nil
+}
+
+func (f *fakeTelemetryStorage) ClearTelemetryEvents(olderThanDays int) (int64, error) {
+	if f.deleteErr != nil {
+		return 0, f.deleteErr
+	}
+	return f.deletedCount, nil
+}
+
+type fakeTelemetryConfig struct {
+	enabled bool
+}
+
+func (f *fakeTelemetryConfig) IsEnabled() bool {
+	return f.enabled
+}
+
+func TestNewTelemetryCmdPanicsWhenStorageIsNil(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatalf("expected panic, got nil")
+		}
+		msg, ok := r.(string)
+		if !ok {
+			t.Fatalf("expected panic message as string, got %T", r)
+		}
+		if !strings.Contains(msg, "storage dependency cannot be nil") {
+			t.Fatalf("expected panic message to mention nil storage, got %q", msg)
+		}
+	}()
+
+	NewTelemetryCmd(nil, &fakeTelemetryConfig{})
+}
+
+func TestNewTelemetryCmdPanicsWhenConfigIsNil(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatalf("expected panic, got nil")
+		}
+		msg, ok := r.(string)
+		if !ok {
+			t.Fatalf("expected panic message as string, got %T", r)
+		}
+		if !strings.Contains(msg, "config dependency cannot be nil") {
+			t.Fatalf("expected panic message to mention nil config, got %q", msg)
+		}
+	}()
+
+	NewTelemetryCmd(&fakeTelemetryStorage{}, nil)
+}
+
+func TestTelemetryShowDisabled(t *testing.T) {
+	client := &telemetryClient{
+		storage: &fakeTelemetryStorage{},
+		config:  &fakeTelemetryConfig{enabled: false},
+	}
+	cmd := newShowTelemetryCmd(client)
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err := cmd.RunE(cmd, []string{})
+	require.NoError(t, err)
+	output := stdout.String() + stderr.String()
+	assert.Contains(t, output, "Telemetry is currently disabled")
+	assert.Contains(t, output, "Data is local-only and never transmitted")
+}
+
+func TestTelemetryShowNoData(t *testing.T) {
+	client := &telemetryClient{
+		storage: &fakeTelemetryStorage{features: []sqlite.FeatureUsage{}},
+		config:  &fakeTelemetryConfig{enabled: true},
+	}
+	cmd := newShowTelemetryCmd(client)
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err := cmd.RunE(cmd, []string{})
+	require.NoError(t, err)
+	output := stdout.String() + stderr.String()
+	assert.Contains(t, output, "No telemetry data available")
+	assert.Contains(t, output, "Data is local-only and never transmitted")
+}
+
+func TestTelemetryShowWithData(t *testing.T) {
+	client := &telemetryClient{
+		storage: &fakeTelemetryStorage{
+			features: []sqlite.FeatureUsage{
+				{FeatureName: "add-notification", FeatureCategory: "cli", UsageCount: 10},
+				{FeatureName: "list-notifications", FeatureCategory: "cli", UsageCount: 5},
+				{FeatureName: "dismiss-notification", FeatureCategory: "cli", UsageCount: 3},
+				{FeatureName: "open-tui", FeatureCategory: "tui", UsageCount: 2},
+			},
+		},
+		config: &fakeTelemetryConfig{enabled: true},
+	}
+	cmd := newShowTelemetryCmd(client)
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err := cmd.RunE(cmd, []string{})
+	require.NoError(t, err)
+	output := stdout.String() + stderr.String()
+	assert.Contains(t, output, "Category: cli")
+	assert.Contains(t, output, "add-notification: 10 calls")
+	assert.Contains(t, output, "list-notifications: 5 calls")
+	assert.Contains(t, output, "Category: tui")
+	assert.Contains(t, output, "open-tui: 2 calls")
+	assert.Contains(t, output, "Data is local-only and never transmitted")
+}
+
+func TestTelemetryShowWithDaysFilter(t *testing.T) {
+	client := &telemetryClient{
+		storage: &fakeTelemetryStorage{
+			features: []sqlite.FeatureUsage{
+				{FeatureName: "add-notification", FeatureCategory: "cli", UsageCount: 10},
+				{FeatureName: "list-notifications", FeatureCategory: "cli", UsageCount: 5},
+			},
+			events: []sqlite.TelemetryEventType{
+				{Timestamp: "2026-01-01T00:00:00Z", FeatureName: "add-notification"},
+			},
+		},
+		config: &fakeTelemetryConfig{enabled: true},
+	}
+	cmd := newShowTelemetryCmd(client)
+	require.NoError(t, cmd.Flags().Set("days", "7"))
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err := cmd.RunE(cmd, []string{})
+	require.NoError(t, err)
+	output := stdout.String() + stderr.String()
+	assert.Contains(t, output, "Data is local-only and never transmitted")
+}
+
+func TestTelemetryShowError(t *testing.T) {
+	client := &telemetryClient{
+		storage: &fakeTelemetryStorage{getAllErr: assert.AnError},
+		config:  &fakeTelemetryConfig{enabled: true},
+	}
+	cmd := newShowTelemetryCmd(client)
+
+	err := cmd.RunE(cmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get feature usage")
+}
+
+func TestTelemetryExportDisabled(t *testing.T) {
+	// Create a temp file
+	tmpFile, err := os.CreateTemp("", "telemetry-export-*.jsonl")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+	tmpFile.Close()
+
+	client := &telemetryClient{
+		storage: &fakeTelemetryStorage{},
+		config:  &fakeTelemetryConfig{enabled: false},
+	}
+	cmd := newExportCmd(client)
+	require.NoError(t, cmd.Flags().Set("output", tmpFile.Name()))
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err = cmd.RunE(cmd, []string{})
+	require.NoError(t, err)
+	output := stdout.String() + stderr.String()
+	assert.Contains(t, output, "Telemetry is currently disabled")
+	assert.Contains(t, output, "Data is local-only and never transmitted")
+}
+
+func TestTelemetryExportNoData(t *testing.T) {
+	// Create a temp file
+	tmpFile, err := os.CreateTemp("", "telemetry-export-*.jsonl")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+	tmpFile.Close()
+
+	client := &telemetryClient{
+		storage: &fakeTelemetryStorage{events: []sqlite.TelemetryEventType{}},
+		config:  &fakeTelemetryConfig{enabled: true},
+	}
+	cmd := newExportCmd(client)
+	require.NoError(t, cmd.Flags().Set("output", tmpFile.Name()))
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err = cmd.RunE(cmd, []string{})
+	require.NoError(t, err)
+	output := stdout.String() + stderr.String()
+	assert.Contains(t, output, "No telemetry data to export")
+	assert.Contains(t, output, "Data is local-only and never transmitted")
+}
+
+func TestTelemetryExportWithData(t *testing.T) {
+	// Create a temp file
+	tmpFile, err := os.CreateTemp("", "telemetry-export-*.jsonl")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+	tmpFile.Close()
+
+	events := []sqlite.TelemetryEventType{
+		{ID: 1, Timestamp: "2026-01-01T00:00:00Z", FeatureName: "add-notification", FeatureCategory: "cli", ContextData: "{}"},
+		{ID: 2, Timestamp: "2026-01-01T01:00:00Z", FeatureName: "list-notifications", FeatureCategory: "cli", ContextData: "{}"},
+	}
+
+	client := &telemetryClient{
+		storage: &fakeTelemetryStorage{events: events},
+		config:  &fakeTelemetryConfig{enabled: true},
+	}
+	cmd := newExportCmd(client)
+	require.NoError(t, cmd.Flags().Set("output", tmpFile.Name()))
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err = cmd.RunE(cmd, []string{})
+	require.NoError(t, err)
+	output := stdout.String() + stderr.String()
+	assert.Contains(t, output, "Exported 2 telemetry events")
+	assert.Contains(t, output, "Data is local-only and never transmitted")
+
+	// Verify file contents
+	content, err := os.ReadFile(tmpFile.Name())
+	require.NoError(t, err)
+	lines := strings.Split(string(content), "\n")
+	assert.Equal(t, 3, len(lines)) // 2 events + 1 empty line
+	assert.Contains(t, lines[0], "add-notification")
+	assert.Contains(t, lines[1], "list-notifications")
+}
+
+func TestTelemetryExportError(t *testing.T) {
+	client := &telemetryClient{
+		storage: &fakeTelemetryStorage{getEventsErr: assert.AnError},
+		config:  &fakeTelemetryConfig{enabled: true},
+	}
+	cmd := newExportCmd(client)
+	require.NoError(t, cmd.Flags().Set("output", "/tmp/test.jsonl"))
+
+	err := cmd.RunE(cmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get telemetry events")
+}
+
+func TestTelemetryClearDisabled(t *testing.T) {
+	client := &telemetryClient{
+		storage: &fakeTelemetryStorage{},
+		config:  &fakeTelemetryConfig{enabled: false},
+	}
+	cmd := newClearTelemetryCmd(client)
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err := cmd.RunE(cmd, []string{})
+	require.NoError(t, err)
+	output := stdout.String() + stderr.String()
+	assert.Contains(t, output, "Telemetry is currently disabled")
+	assert.Contains(t, output, "Data is local-only and never transmitted")
+}
+
+func TestTelemetryClearNoData(t *testing.T) {
+	t.Setenv("TMUX_INTRAY_ALLOW_NO_TMUX", "true")
+	client := &telemetryClient{
+		storage: &fakeTelemetryStorage{deletedCount: 0},
+		config:  &fakeTelemetryConfig{enabled: true},
+	}
+	cmd := newClearTelemetryCmd(client)
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err := cmd.RunE(cmd, []string{})
+	require.NoError(t, err)
+	output := stdout.String() + stderr.String()
+	assert.Contains(t, output, "No telemetry data to clear")
+	assert.Contains(t, output, "Data is local-only and never transmitted")
+}
+
+func TestTelemetryClearWithData(t *testing.T) {
+	t.Setenv("TMUX_INTRAY_ALLOW_NO_TMUX", "true")
+	client := &telemetryClient{
+		storage: &fakeTelemetryStorage{deletedCount: 5},
+		config:  &fakeTelemetryConfig{enabled: true},
+	}
+	cmd := newClearTelemetryCmd(client)
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err := cmd.RunE(cmd, []string{})
+	require.NoError(t, err)
+	output := stdout.String() + stderr.String()
+	assert.Contains(t, output, "Cleared 5 telemetry event(s)")
+	assert.Contains(t, output, "Data is local-only and never transmitted")
+}
+
+func TestTelemetryClearWithDays(t *testing.T) {
+	client := &telemetryClient{
+		storage: &fakeTelemetryStorage{deletedCount: 3},
+		config:  &fakeTelemetryConfig{enabled: true},
+	}
+	cmd := newClearTelemetryCmd(client)
+	require.NoError(t, cmd.Flags().Set("days", "7"))
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err := cmd.RunE(cmd, []string{})
+	require.NoError(t, err)
+	output := stdout.String() + stderr.String()
+	assert.Contains(t, output, "Cleared 3 telemetry event(s)")
+	assert.Contains(t, output, "Data is local-only and never transmitted")
+}
+
+func TestTelemetryClearError(t *testing.T) {
+	t.Setenv("TMUX_INTRAY_ALLOW_NO_TMUX", "true")
+	client := &telemetryClient{
+		storage: &fakeTelemetryStorage{deleteErr: assert.AnError},
+		config:  &fakeTelemetryConfig{enabled: true},
+	}
+	cmd := newClearTelemetryCmd(client)
+
+	err := cmd.RunE(cmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to clear telemetry events")
+}
+
+func TestTelemetryStatusDisabled(t *testing.T) {
+	client := &telemetryClient{
+		storage: &fakeTelemetryStorage{},
+		config:  &fakeTelemetryConfig{enabled: false},
+	}
+	cmd := newStatusTelemetryCmd(client)
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err := cmd.RunE(cmd, []string{})
+	require.NoError(t, err)
+	output := stdout.String() + stderr.String()
+	assert.Contains(t, output, "Telemetry Status")
+	assert.Contains(t, output, "Enabled:")
+	assert.Contains(t, output, "Data is local-only and never transmitted")
+}
+
+func TestTelemetryStatusEnabled(t *testing.T) {
+	events := []sqlite.TelemetryEventType{
+		{Timestamp: "2026-01-01T00:00:00Z", FeatureName: "add-notification"},
+		{Timestamp: "2026-01-01T01:00:00Z", FeatureName: "list-notifications"},
+	}
+	client := &telemetryClient{
+		storage: &fakeTelemetryStorage{events: events},
+		config:  &fakeTelemetryConfig{enabled: true},
+	}
+	cmd := newStatusTelemetryCmd(client)
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err := cmd.RunE(cmd, []string{})
+	require.NoError(t, err)
+	output := stdout.String() + stderr.String()
+	assert.Contains(t, output, "Telemetry Status")
+	assert.Contains(t, output, "Enabled:")
+	assert.Contains(t, output, "Total Events: 2")
+	assert.Contains(t, output, "First Event: 2026-01-01T00:00:00Z")
+	assert.Contains(t, output, "Last Event: 2026-01-01T01:00:00Z")
+	assert.Contains(t, output, "Data is local-only and never transmitted")
+}
+
+func TestTelemetryStatusError(t *testing.T) {
+	client := &telemetryClient{
+		storage: &fakeTelemetryStorage{getEventsErr: assert.AnError},
+		config:  &fakeTelemetryConfig{enabled: true},
+	}
+	cmd := newStatusTelemetryCmd(client)
+
+	err := cmd.RunE(cmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get status")
+}
+
+func TestFormatBool(t *testing.T) {
+	tests := []struct {
+		name string
+		b    bool
+		want string
+	}{
+		{"true", true, "\033[0;32mtrue\033[0m"},
+		{"false", false, "\033[0;31mfalse\033[0m"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatBool(tt.b)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestFilterFeaturesByDays(t *testing.T) {
+	features := []sqlite.FeatureUsage{
+		{FeatureName: "add-notification", FeatureCategory: "cli", UsageCount: 10},
+		{FeatureName: "list-notifications", FeatureCategory: "cli", UsageCount: 5},
+	}
+	// Use relative timestamp to ensure test passes regardless of when it runs
+	events := []sqlite.TelemetryEventType{
+		{Timestamp: time.Now().UTC().AddDate(0, 0, -1).Format(time.RFC3339), FeatureName: "add-notification"},
+	}
+	client := &telemetryClient{
+		storage: &fakeTelemetryStorage{
+			features: features,
+			events:   events,
+		},
+		config: &fakeTelemetryConfig{enabled: true},
+	}
+
+	filtered, err := filterFeaturesByDays(client, features, 7)
+	require.NoError(t, err)
+	assert.Len(t, filtered, 1)
+	assert.Equal(t, "add-notification", filtered[0].FeatureName)
+}
+
+func TestTelemetryConfigAdapter(t *testing.T) {
+	adapter := &telemetryConfigAdapter{}
+	enabled := adapter.IsEnabled()
+	// The result depends on config, just check it returns a bool
+	assert.IsType(t, false, enabled)
+}

--- a/internal/ports/telemetry.go
+++ b/internal/ports/telemetry.go
@@ -1,0 +1,27 @@
+// Package ports defines application boundary interfaces used by core services.
+package ports
+
+// TelemetryEventType represents a telemetry event returned from storage.
+type TelemetryEventType struct {
+	ID              int64
+	Timestamp       string
+	FeatureName     string
+	FeatureCategory string
+	ContextData     string
+}
+
+// FeatureUsage represents feature usage statistics.
+type FeatureUsage struct {
+	FeatureName     string
+	FeatureCategory string
+	UsageCount      int64
+}
+
+// TelemetryStorage defines the interface for telemetry storage operations.
+// This interface bridges cmd and storage layers without requiring cmd to import concrete adapters.
+type TelemetryStorage interface {
+	GetFeatureUsage(featureName string) (int64, error)
+	GetAllFeatures() ([]FeatureUsage, error)
+	GetTelemetryEvents(startTime, endTime string) ([]TelemetryEventType, error)
+	ClearTelemetryEvents(olderThanDays int) (int64, error)
+}

--- a/internal/storage/sqlite/telemetry.go
+++ b/internal/storage/sqlite/telemetry.go
@@ -7,24 +7,14 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/cristianoliveira/tmux-intray/internal/ports"
 	"github.com/cristianoliveira/tmux-intray/internal/storage/sqlite/sqlcgen"
 )
 
-// TelemetryEventType represents a telemetry event returned from storage.
-type TelemetryEventType struct {
-	ID              int64
-	Timestamp       string
-	FeatureName     string
-	FeatureCategory string
-	ContextData     string
-}
-
-// FeatureUsage represents feature usage statistics.
-type FeatureUsage struct {
-	FeatureName     string
-	FeatureCategory string
-	UsageCount      int64
-}
+// Local type aliases for convenience within sqlite package.
+// The canonical types are defined in internal/ports package.
+type TelemetryEventType = ports.TelemetryEventType
+type FeatureUsage = ports.FeatureUsage
 
 // LogTelemetryEvent logs a telemetry event to storage.
 func (s *SQLiteStorage) LogTelemetryEvent(timestamp, featureName, featureCategory, contextData string) error {


### PR DESCRIPTION
This commit implements a comprehensive CLI for managing telemetry data, including four subcommands for viewing, exporting, clearing, and checking telemetry status.

## Implementation

### CLI Commands (cmd/tmux-intray/telemetry.go)
- telemetry show [--days N]: Display feature usage summary grouped by category
- telemetry export --output FILE: Export telemetry data to JSONL format
- telemetry clear [--days N]: Clear telemetry events older than N days (default: 90)
- telemetry status: Show telemetry status including enabled state, total events, and timestamps

### Dependency Injection (cmd/tmux-intray/deps.go)
- Added telemetryStorage field to cliDeps struct
- Registered TelemetryStorage interface via type assertion from storage layer
- Conditionally register telemetry command only when TelemetryStorage is available

### Ports Interface (internal/ports/telemetry.go)
- Defined TelemetryStorage interface to bridge cmd and storage layers
- Moved TelemetryEventType and FeatureUsage types to ports package
- Ensures proper layering and prevents depguard violations

### Storage Layer Updates (internal/storage/sqlite/telemetry.go)
- Updated to import and use types from internal/ports
- Implemented TelemetryStorage interface methods
- Maintained backward compatibility with type aliases

### Test Coverage (cmd/tmux-intray/telemetry_test.go)
- 20+ test cases covering all subcommands and edge cases
- Tests for disabled telemetry state, empty data, error conditions
- Tests for flag parsing, output formatting, and privacy warnings
- Fake implementations for storage and config interfaces

## Privacy

All telemetry commands include prominent privacy warnings:
- Data is local-only and never transmitted
- Privacy warnings displayed on stderr for all commands
- Clear command requires confirmation (except in CI/test mode)

## Testing
All CI checks passed (tests, formatting, linting, build, security)
20+ test cases with comprehensive coverage
Proper layering with ports interface

## Related
- Beads task: tmux-intray-vjk
- Parent epic: tmux-intray-vbi