### PR TITLE
refactor(cli): delegate add/list/status to shared app use cases + tui keymap fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
             GOARCH=${PLATFORM#*/}
             output="dist/tmux-intray_${GOOS}_${GOARCH}"
             if [ "$GOOS" = "windows" ]; then output="${output}.exe"; fi
-            GOOS=$GOOS GOARCH=$GOARCH go build -ldflags="-X github.com/cristianoliveira/tmux-intray/cmd.Version=$VERSION" -o "$output" ./cmd/tmux-intray
+            GOOS=$GOOS GOARCH=$GOARCH go build -ldflags="-X github.com/cristianoliveira/tmux-intray/internal/version.Version=$VERSION" -o "$output" ./cmd/tmux-intray
             echo "Built: $output"
           done
 
@@ -80,7 +80,7 @@ jobs:
             else
               # Unix-like binary - check if executable and reports version
               if [ -x "$binary" ]; then
-                version_output=$("$binary" version 2>&1 || true)
+                version_output=$("$binary" --version 2>&1 || true)
                 if [[ "$version_output" == *"tmux-intray v"* ]]; then
                   echo "✓ Unix binary verified: $(basename "$binary")"
                 else

--- a/README.md
+++ b/README.md
@@ -176,22 +176,22 @@ Comprehensive documentation is available:
 - [Status Guide](docs/status-guide.md) - Template variables, presets, real-world examples, and troubleshooting
 - [Configuration Guide](docs/configuration.md) - All environment variables and settings (including TUI settings persistence)
 - [Troubleshooting Guide](docs/troubleshooting.md) - Common issues and solutions
-- [Advanced Filtering Example](examples/advanced-filtering.sh) - Complex filter combinations
+- [Advanced Filtering Example](examples/advanced-filtering.md) - Complex filter combinations
 - [Man page](man/man1/tmux-intray.1) - Traditional manual page (view with `man -l man/man1/tmux-intray.1`)
 
-Documentation is automatically generated from the command-line help texts.
+Some docs mirror command help text, but the Markdown guides also include additional examples and operational notes.
 
 ### TUI Settings Persistence
 
 The TUI automatically saves your preferences on exit:
 - **Settings file**: `~/.config/tmux-intray/tui.toml`
-- **Auto-save**: Settings are saved when you quit (q, :q, Ctrl+C)
+- **Auto-save**: Settings are saved when you quit (`q`, `Ctrl+C`) and when switching tabs in the TUI
 - **Reset settings**: Run `tmux-intray settings reset`
 - **View settings**: Run `tmux-intray settings show`
 
 See [Configuration Guide](docs/configuration.md) for details on available settings.
 
-For a comprehensive list of filters and detailed examples, see the [CLI Reference](docs/cli/CLI_REFERENCE.md) and the [advanced filtering example](examples/advanced-filtering.sh).
+For a comprehensive list of filters and detailed examples, see the [CLI Reference](docs/cli/CLI_REFERENCE.md) and the [advanced filtering example](examples/advanced-filtering.md).
 
 ### Hooks system
 
@@ -274,7 +274,7 @@ tmux-intray is built with a modular architecture that separates concerns:
 │   CLI Core      │           Tmux Integration                │
 │   (Go-based)    │        (tmux-intray.tmux)                 │
 ├─────────────────┼───────────────────────────────────────────┤
-│ • Storage       │ • Key bindings (prefix+I, prefix+J)       │
+│ • Storage       │ • Key bindings (prefix+J)                 │
 │ • Commands      │ • Status bar updates                      │
 │ • Hooks system  │ • Pane context capture                    │
 │ • Configuration │ • Environment setup                       │

--- a/cmd/tmux-intray/add.go
+++ b/cmd/tmux-intray/add.go
@@ -4,10 +4,7 @@ Copyright © 2026 Cristian Oliveira <license@cristianoliveira.dev>
 package main
 
 import (
-	"fmt"
-	"strings"
-
-	"github.com/cristianoliveira/tmux-intray/internal/colors"
+	appcore "github.com/cristianoliveira/tmux-intray/internal/app"
 	"github.com/spf13/cobra"
 )
 
@@ -65,59 +62,22 @@ the current tmux pane (if inside tmux). Use --no-associate to skip.`,
 
 // runAddCmd executes the add command logic.
 func runAddCmd(client addClient, args []string, sessionFlag, windowFlag, paneFlag, paneCreatedFlag string, noAssociateFlag bool, levelFlag string) error {
-	// Treat empty strings same as not provided (e.g., --session="" from plugin)
-	// This makes the CLI resilient to the plugin passing empty flag values
-	sessionFlag = strings.TrimSpace(sessionFlag)
-	windowFlag = strings.TrimSpace(windowFlag)
-	paneFlag = strings.TrimSpace(paneFlag)
-
-	needsAutoAssociation := !noAssociateFlag && sessionFlag == "" && windowFlag == "" && paneFlag == ""
-	if needsAutoAssociation && !client.EnsureTmuxRunning() {
-		if allowTmuxlessMode() {
-			colors.Warning("tmux not running; adding notification without pane association")
-			noAssociateFlag = true
-		} else {
-			return fmt.Errorf("tmux not running")
-		}
-	}
-
-	// Join arguments as message (bash style)
-	message := strings.Join(args, " ")
-
-	// Validate message
-	if err := validateMessage(message); err != nil {
-		return err
-	}
-
-	// Message is stored as-is; storage layer handles timestamps
-	formattedMessage := message
-
-	// Determine level
-	level := levelFlag
-	if level == "" {
-		level = "info"
-	}
-
-	// Add tray item
-	_, err := client.AddTrayItem(formattedMessage, sessionFlag, windowFlag, paneFlag, paneCreatedFlag, noAssociateFlag, level)
-	if err != nil {
-		return fmt.Errorf("add: failed to add tray item: %w", err)
-	}
-
-	colors.Success("added")
-	return nil
+	useCase := appcore.NewAddUseCase(client)
+	return useCase.Execute(appcore.AddInput{
+		Args:        args,
+		Session:     sessionFlag,
+		Window:      windowFlag,
+		Pane:        paneFlag,
+		PaneCreated: paneCreatedFlag,
+		NoAssociate: noAssociateFlag,
+		Level:       levelFlag,
+		AllowTmuxless: func() bool {
+			return allowTmuxlessMode()
+		},
+	})
 }
 
 // validateMessage checks message length and emptiness (matches Bash validation)
 func validateMessage(message string) error {
-	// Check length
-	if len(message) > 1000 {
-		return fmt.Errorf("add: message too long (max 1000 characters)")
-	}
-	// Check if empty after stripping whitespace
-	trimmed := strings.TrimSpace(message)
-	if trimmed == "" {
-		return fmt.Errorf("add: message cannot be empty")
-	}
-	return nil
+	return appcore.ValidateAddMessage(message)
 }

--- a/cmd/tmux-intray/list.go
+++ b/cmd/tmux-intray/list.go
@@ -7,31 +7,16 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"sort"
 	"strings"
 	"time"
 
-	"github.com/cristianoliveira/tmux-intray/internal/colors"
-	"github.com/cristianoliveira/tmux-intray/internal/dedupconfig"
+	appcore "github.com/cristianoliveira/tmux-intray/internal/app"
 	"github.com/cristianoliveira/tmux-intray/internal/domain"
-	"github.com/cristianoliveira/tmux-intray/internal/format"
-	"github.com/cristianoliveira/tmux-intray/internal/notification"
-	"github.com/cristianoliveira/tmux-intray/internal/search"
-	"github.com/cristianoliveira/tmux-intray/internal/tmux"
 	"github.com/spf13/cobra"
 )
 
 type listClient interface {
 	ListNotifications(stateFilter, levelFilter, sessionFilter, windowFilter, paneFilter, olderThanCutoff, newerThanCutoff, readFilter string) (string, error)
-}
-
-// notificationsToValues converts a slice of notification pointers to values.
-func notificationsToValues(notifs []*domain.Notification) []domain.Notification {
-	values := make([]domain.Notification, len(notifs))
-	for i, n := range notifs {
-		values[i] = *n
-	}
-	return values
 }
 
 const listCommandLong = `List notifications with filters and formats.
@@ -243,22 +228,15 @@ var listOutputWriter io.Writer = os.Stdout
 var listListFunc func(state, level, session, window, pane, olderThan, newerThan, readFilter string) (string, error)
 
 // FilterOptions holds all filter parameters for listing notifications.
-type FilterOptions struct {
-	Client         listClient
-	State          string
-	Level          string
-	Session        string
-	Window         string
-	Pane           string
-	OlderThan      string // timestamp cutoff (>=)
-	NewerThan      string // timestamp cutoff (<=)
-	Search         string
-	Regex          bool
-	GroupBy        string
-	GroupCount     bool
-	Format         string          // legacy, table, compact, json
-	SearchProvider search.Provider // Optional custom search provider (for testing/extension)
-	ReadFilter     string          // read status filter: "read", "unread", or "" (no filter)
+type FilterOptions = appcore.ListOptions
+
+type listFuncClient struct{}
+
+func (listFuncClient) ListNotifications(state, level, session, window, pane, olderThan, newerThan, readFilter string) (string, error) {
+	if listListFunc == nil {
+		return "", fmt.Errorf("list: missing client")
+	}
+	return listListFunc(state, level, session, window, pane, olderThan, newerThan, readFilter)
 }
 
 // PrintList prints notifications according to the provided filter options.
@@ -270,146 +248,17 @@ func PrintList(opts FilterOptions) {
 }
 
 func printList(opts FilterOptions, w io.Writer) {
-	lines, err := fetchNotifications(opts)
-	if err != nil {
-		_, _ = fmt.Fprintf(w, "list: failed to list notifications: %v\n", err)
-		return
-	}
-	if lines == "" {
-		_, _ = fmt.Fprintf(w, "%s%s%s\n", colors.Blue, "No notifications found", colors.Reset)
-		return
+	client := opts.Client
+	if client == nil {
+		client = listFuncClient{}
 	}
 
-	searchProvider := getSearchProvider(opts)
-	notifications := parseAndFilterNotifications(lines, searchProvider, opts.Search)
-	if len(notifications) == 0 {
-		_, _ = fmt.Fprintf(w, "%s%s%s\n", colors.Blue, "No notifications found", colors.Reset)
-		return
-	}
-
-	notifications = orderUnreadFirst(notifications)
-	printNotifications(notifications, opts, w)
-}
-
-// fetchNotifications retrieves notifications from storage.
-func fetchNotifications(opts FilterOptions) (string, error) {
-	if opts.Client != nil {
-		return opts.Client.ListNotifications(opts.State, opts.Level, opts.Session, opts.Window, opts.Pane, opts.OlderThan, opts.NewerThan, opts.ReadFilter)
-	}
-	if listListFunc != nil {
-		return listListFunc(opts.State, opts.Level, opts.Session, opts.Window, opts.Pane, opts.OlderThan, opts.NewerThan, opts.ReadFilter)
-	}
-	return "", fmt.Errorf("list: missing client")
-}
-
-// getSearchProvider returns the appropriate search provider based on options.
-func getSearchProvider(opts FilterOptions) search.Provider {
-	if opts.SearchProvider != nil {
-		return opts.SearchProvider
-	}
-	if opts.Search == "" {
-		return nil
-	}
-
-	// Fetch name maps for transparent name-based search
-	client := tmux.NewDefaultClient()
-	sessionNames, _ := client.ListSessions()
-	if sessionNames == nil {
-		sessionNames = make(map[string]string)
-	}
-	windowNames, _ := client.ListWindows()
-	if windowNames == nil {
-		windowNames = make(map[string]string)
-	}
-	paneNames, _ := client.ListPanes()
-	if paneNames == nil {
-		paneNames = make(map[string]string)
-	}
-
-	// Create default provider based on Regex flag
-	if opts.Regex {
-		return search.NewRegexProvider(
-			search.WithCaseInsensitive(false),
-			search.WithSessionNames(sessionNames),
-			search.WithWindowNames(windowNames),
-			search.WithPaneNames(paneNames),
-		)
-	}
-	return search.NewSubstringProvider(
-		search.WithCaseInsensitive(false),
-		search.WithSessionNames(sessionNames),
-		search.WithWindowNames(windowNames),
-		search.WithPaneNames(paneNames),
-	)
-}
-
-// parseAndFilterNotifications parses and filters notification lines.
-func parseAndFilterNotifications(lines string, searchProvider search.Provider, searchQuery string) []*domain.Notification {
-	var notifications []*domain.Notification
-	for _, line := range strings.Split(lines, "\n") {
-		if line == "" {
-			continue
-		}
-		notif, err := notification.ParseNotification(line)
-		if err != nil {
-			continue
-		}
-		// Apply search filter using search provider
-		if searchProvider != nil {
-			if !searchProvider.Match(notif, searchQuery) {
-				continue
-			}
-		}
-		notifications = append(notifications, notification.ToDomainUnsafe(notif))
-	}
-	return notifications
-}
-
-// printNotifications prints notifications based on options.
-func printNotifications(notifications []*domain.Notification, opts FilterOptions, w io.Writer) {
-	// Apply grouping if requested
-	if opts.GroupBy != "" {
-		notificationsValues := notificationsToValues(notifications)
-		var groupResult domain.GroupResult
-		if opts.GroupBy == domain.GroupByMessage.String() {
-			groupResult = domain.GroupNotificationsWithDedup(notificationsValues, domain.GroupByMode(opts.GroupBy), dedupconfig.Load())
-		} else {
-			groupResult = domain.GroupNotifications(notificationsValues, domain.GroupByMode(opts.GroupBy))
-		}
-		formatter := format.GetFormatter(opts.Format, opts.GroupCount)
-		err := formatter.FormatGroups(groupResult, w)
-		if err != nil {
-			_, _ = fmt.Fprintf(w, "list: formatting error: %v\n", err)
-		}
-		return
-	}
-
-	// No grouping, use appropriate formatter
-	formatter := format.GetFormatter(opts.Format, false)
-	err := formatter.FormatNotifications(notifications, w)
-	if err != nil {
-		_, _ = fmt.Fprintf(w, "list: formatting error: %v\n", err)
-	}
+	useCase := appcore.NewListUseCase(client)
+	useCase.Execute(appcore.ListOptions(opts), w)
 }
 
 // orderUnreadFirst places unread notifications before read notifications.
 // It keeps the existing relative order within each bucket (stable).
 func orderUnreadFirst(notifs []*domain.Notification) []*domain.Notification {
-	if len(notifs) == 0 {
-		return notifs
-	}
-
-	ordered := make([]*domain.Notification, len(notifs))
-	copy(ordered, notifs)
-
-	sort.SliceStable(ordered, func(i, j int) bool {
-		iUnread := !ordered[i].IsRead()
-		jUnread := !ordered[j].IsRead()
-		if iUnread == jUnread {
-			return false
-		}
-		return iUnread && !jUnread
-	})
-
-	return ordered
+	return appcore.OrderUnreadFirst(notifs)
 }

--- a/cmd/tmux-intray/status.go
+++ b/cmd/tmux-intray/status.go
@@ -4,14 +4,10 @@ Copyright © 2026 Cristian Oliveira <license@cristianoliveira.dev>
 package main
 
 import (
-	"fmt"
 	"io"
 	"os"
-	"strings"
 
-	"github.com/cristianoliveira/tmux-intray/internal/domain"
-	"github.com/cristianoliveira/tmux-intray/internal/format"
-	"github.com/cristianoliveira/tmux-intray/internal/formatter"
+	appcore "github.com/cristianoliveira/tmux-intray/internal/app"
 	"github.com/spf13/cobra"
 )
 
@@ -40,13 +36,13 @@ USAGE:
 OPTIONS:
     --format=<format>    Output format: preset name or custom template (default: compact)
 
-PRESETS (6):
+PRESETS / FORMATS (6):
     compact      [{{unread-count}}] {{latest-message}}
     detailed     {{unread-count}} unread, {{read-count}} read | Latest: {{latest-message}}
-    json         {"unread":{{unread-count}},"total":{{total-count}},"message":"{{latest-message}}"}
+    json         Special JSON output with counts and pane breakdown
     count-only   {{unread-count}}
-    levels       Severity: {{highest-severity}} | Unread: {{unread-count}}
-    panes        {{pane-list}} ({{unread-count}})
+    levels       Special multi-line severity count output
+    panes        Special pane-count output
 
 VARIABLES (13):
     {{unread-count}}      Number of active notifications
@@ -81,13 +77,7 @@ EXAMPLES:
 See docs/status-guide.md for detailed documentation and more examples.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Ensure tmux is running (mirror bash script behavior)
-			if !client.EnsureTmuxRunning() {
-				return fmt.Errorf("tmux not running")
-			}
-
 			format := determineStatusFormat(cmd, formatFlag)
-
 			w := cmd.OutOrStdout()
 			return runStatusCommandWithFormat(client, format, w)
 		},
@@ -99,163 +89,19 @@ See docs/status-guide.md for detailed documentation and more examples.`,
 
 // determineStatusFormat determines the output format, preferring flag over env.
 func determineStatusFormat(cmd *cobra.Command, formatFlag string) string {
-	format := formatFlag
-	if !cmd.Flag("format").Changed {
-		if envFormat := os.Getenv("TMUX_INTRAY_STATUS_FORMAT"); envFormat != "" {
-			format = envFormat
-		}
-	}
-	if format == "" {
-		format = "compact"
-	}
-	return format
+	return appcore.DetermineStatusFormat(formatFlag, os.Getenv("TMUX_INTRAY_STATUS_FORMAT"), cmd.Flag("format").Changed)
 }
 
 // runStatusCommandWithFormat executes the status command with format support.
-// It handles both preset names and custom templates.
 func runStatusCommandWithFormat(client statusClient, format string, w io.Writer) error {
-	// Handle legacy format names for backward compatibility
-	switch format {
-	case "summary":
-		return formatSummary(client, w)
-	case "levels":
-		return formatLevels(client, w)
-	case "panes":
-		return formatPanes(client, w)
-	case "json":
-		return formatJSON(client, w)
-	}
-
-	// Check if it's a formatter preset (new system)
-	registry := formatter.NewPresetRegistry()
-	if preset, err := registry.Get(format); err == nil {
-		// It's a preset, use the template from it
-		return runStatusWithTemplate(client, preset.Template, w)
-	}
-
-	// Otherwise treat it as a custom template
-	return runStatusWithTemplate(client, format, w)
+	useCase := appcore.NewStatusUseCase(client)
+	return useCase.Execute(format, w)
 }
 
-// runStatusWithTemplate executes status with a template string.
-func runStatusWithTemplate(client statusClient, template string, w io.Writer) error {
-	// Create the variable context with current status data
-	ctx := buildVariableContext(client)
-
-	// Create template engine and substitute
-	engine := formatter.NewTemplateEngine()
-	result, err := engine.Substitute(template, ctx)
-	if err != nil {
-		return fmt.Errorf("template substitution error: %w", err)
-	}
-
-	_, err = fmt.Fprintln(w, result)
-	return err
-}
-
-// buildVariableContext creates a VariableContext from current status data.
-func buildVariableContext(client statusClient) formatter.VariableContext {
-	active := countByState(client, "active")
-	dismissed := countByState(client, "dismissed")
-	read := countByState(client, "dismissed") // read items are dismissed
-	infoCount, warningCount, errorCount, criticalCount := countByLevel(client)
-
-	// Get latest message
-	latestMsg := ""
-	lines, _ := client.ListNotifications("active", "", "", "", "", "", "", "")
-	if lines != "" {
-		fields := strings.Split(strings.Split(lines, "\n")[0], "\t")
-		if len(fields) > 6 {
-			latestMsg = fields[6]
-		}
-	}
-
-	// Determine highest severity
-	highestSeverity := domain.LevelInfo
-	if criticalCount > 0 {
-		highestSeverity = domain.LevelCritical
-	} else if errorCount > 0 {
-		highestSeverity = domain.LevelError
-	} else if warningCount > 0 {
-		highestSeverity = domain.LevelWarning
-	}
-
-	return formatter.VariableContext{
-		UnreadCount:     active,
-		TotalCount:      active, // alias for unread
-		ReadCount:       read,
-		ActiveCount:     active,
-		DismissedCount:  dismissed,
-		InfoCount:       infoCount,
-		WarningCount:    warningCount,
-		ErrorCount:      errorCount,
-		CriticalCount:   criticalCount,
-		LatestMessage:   latestMsg,
-		HasUnread:       active > 0,
-		HasActive:       active > 0,
-		HasDismissed:    dismissed > 0,
-		HighestSeverity: highestSeverity,
-		SessionList:     "",
-		WindowList:      "",
-		PaneList:        "",
-	}
-}
-
-// Helper functions
-
-func countByState(client statusClient, state string) int {
-	lines, err := client.ListNotifications(state, "", "", "", "", "", "", "")
-	if err != nil || lines == "" {
-		return 0
-	}
-	count := 0
-	for _, line := range strings.Split(lines, "\n") {
-		if line != "" {
-			count++
-		}
-	}
-	return count
-}
-
-func countByLevel(client statusClient) (info, warning, error, critical int) {
-	lines, err := client.ListNotifications("active", "", "", "", "", "", "", "")
-	if err != nil || lines == "" {
-		return
-	}
-	info, warning, error, critical, _ = format.ParseCountsByLevel(lines)
-	return
+func countByLevel(client statusClient) (info, warning, errCount, critical int) {
+	return appcore.CountByLevel(client)
 }
 
 func paneCounts(client statusClient) map[string]int {
-	lines, err := client.ListNotifications("active", "", "", "", "", "", "", "")
-	if err != nil || lines == "" {
-		return make(map[string]int)
-	}
-	return format.ParsePaneCounts(lines)
-}
-
-func formatSummary(client statusClient, w io.Writer) error {
-	active := countByState(client, "active")
-	if active == 0 {
-		return format.FormatSummary(w, 0, 0, 0, 0, 0)
-	}
-	info, warning, error, critical := countByLevel(client)
-	return format.FormatSummary(w, active, info, warning, error, critical)
-}
-
-func formatLevels(client statusClient, w io.Writer) error {
-	info, warning, error, critical := countByLevel(client)
-	return format.FormatLevels(w, info, warning, error, critical)
-}
-
-func formatPanes(client statusClient, w io.Writer) error {
-	counts := paneCounts(client)
-	return format.FormatPanes(w, counts)
-}
-
-func formatJSON(client statusClient, w io.Writer) error {
-	active := countByState(client, "active")
-	info, warning, error, critical := countByLevel(client)
-	counts := paneCounts(client)
-	return format.FormatJSON(w, active, info, warning, error, critical, counts)
+	return appcore.PaneCounts(client)
 }

--- a/cmd/tmux-intray/status_test.go
+++ b/cmd/tmux-intray/status_test.go
@@ -336,7 +336,7 @@ func TestStatusHelpIncludesTemplateExamples(t *testing.T) {
 	require.NoError(t, err)
 	help := stdout.String()
 
-	assert.Contains(t, help, "PRESETS (6):")
+	assert.Contains(t, help, "PRESETS / FORMATS (6):")
 	assert.Contains(t, help, "{{unread-count}}")
 	assert.Contains(t, help, "{{critical-count}}")
 	assert.Contains(t, help, "tmux-intray status --format='{{unread-count}} new messages'")

--- a/cmd/tmux-intray/tui.go
+++ b/cmd/tmux-intray/tui.go
@@ -34,18 +34,23 @@ func NewTUICmd(client tuiClient) *cobra.Command {
 USAGE:
     tmux-intray tui
 
-			KEY BINDINGS:
-			    j/k         Move up/down in the list
-			    /           Enter search mode
+KEY BINDINGS:
+    j/k         Move up/down in the list
+    r/a         Switch to Recents / All tabs
+    Ctrl+s      Switch to Sessions tab
+    /           Enter search mode
+    Ctrl+v      Cycle view mode (detailed/grouped/search)
+    ESC         Exit search mode, or quit TUI
+    d           Dismiss selected notification
+    R           Mark selected notification as read
+    u           Mark selected notification as unread
+    Enter       Jump to pane/window target
+    q           Quit TUI
 
-			    v           Cycle view mode (detailed/grouped/search)
-			    ESC         Exit search mode, or quit TUI
-			    d           Dismiss selected notification
-			    r           Mark selected notification as read
-			    u           Mark selected notification as unread
-    Enter       Jump to pane
-    :w          Save settings
-    q           Quit TUI`,
+NOTES:
+    - Settings are saved automatically on quit.
+    - Up/Down arrows are supported in search contexts.
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Load settings from disk (use defaults if missing/corrupted)
 			loadedSettings, err := client.LoadSettings()

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -41,7 +41,7 @@ Triggered when a tag matching `v[0-9]*.[0-9]*.[0-9]*` is pushed.
 **Jobs:**
 
 1. **create-release** - Creates GitHub release and artifacts:
-   - Verifies version consistency between tag and binary
+   - Verifies the tag format and injects the release version at build time via Go ldflags
    - Generates documentation (man pages and CLI reference)
    - Builds Go binaries for multiple platforms (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64)
    - Generates release notes from git history
@@ -50,7 +50,7 @@ Triggered when a tag matching `v[0-9]*.[0-9]*.[0-9]*` is pushed.
 
 ## How to Release
 
-1. **Version Bump**: Ensure `bin/tmux-intray` contains the correct version in its `VERSION` variable.
+1. **Version source**: The release version comes from the git tag and is injected into the binary at build time via Go ldflags.
 
 2. **Create Tag**:
    ```bash
@@ -107,9 +107,10 @@ pre-commit install
 
 ### Release Failures
 
-#### Version Mismatch
-Error: "Version mismatch between bin/tmux-intray and git tag"
-- Ensure the `VERSION` variable in `bin/tmux-intray` matches the git tag (without leading 'v')
+#### Version / tag issues
+Error: invalid tag format or incorrect release version
+- Ensure the git tag matches `vMAJOR.MINOR.PATCH` (for example `v1.2.3`)
+- The workflow strips the leading `v` and injects the resulting version into the binary during build
 
 ## Extending the Pipeline
 

--- a/docs/cli/CLI_REFERENCE.md
+++ b/docs/cli/CLI_REFERENCE.md
@@ -16,24 +16,24 @@ Usage:
   tmux-intray [command]
 
 Available Commands:
-  add          Add a new item to the tray
-  cleanup      Clean up old dismissed notifications
-  clear        Clear all items from the tray
-  dismiss      Dismiss a notification
-  follow       Monitor notifications in real-time
-  help         Help about any command
-  jump         Jump to the pane of a notification
-  list         List notifications with filters and formats
-  mark-read    Mark a notification as read
-  settings     Manage TUI settings
-  status       Show notification status summary
-  tui          Interactive terminal UI for notifications
-  version      Show version information
+  add         Add a new item to the tray
+  cleanup     Clean up old dismissed notifications
+  clear       Clear all items from the tray
+  completion  Generate the autocompletion script for the specified shell
+  dismiss     Dismiss a notification
+  follow      Monitor notifications in real-time
+  help        Help about any command
+  jump        Jump to the pane of a notification
+  list        List notifications with filters and formats
+  mark-read   Mark a notification as read
+  settings    Manage TUI settings
+  status      Show notification status summary
+  tui         Interactive terminal UI for notifications
 
 Flags:
-  -h, --help               help for tmux-intray
-  -v, --version            version for tmux-intray
-      --log-file string    log file path (default empty, logs to stderr)
+  -h, --help              help for tmux-intray
+      --log-file string   explicit log file path (overrides config)
+  -v, --version           version for tmux-intray
 
 Use "tmux-intray [command] --help" for more information about a command.
 ```
@@ -71,9 +71,11 @@ Launches the interactive notifications UI.
 
 - `r` - switch to Recents tab
 - `a` - switch to All tab
+- `Ctrl+s` - switch to Sessions tab
 - `R` - mark selected notification as read
 - `u` - mark selected notification as unread
 - `Enter` - jump to selected notification target (pane when available, window fallback)
+- `Up` / `Down` - navigate while in search contexts
 
 ### status
 
@@ -81,7 +83,7 @@ Launches the interactive notifications UI.
 tmux-intray status [flags]
 ```
 
-Show notification status summary with template-based formatting. Supports 13 template variables and 6 built-in presets, plus custom templates for flexible output.
+Show notification status summary with template-based formatting. Supports 13 core template variables plus 4 severity-count variables, 6 built-in presets, and custom templates for flexible output.
 
 #### Presets (Built-in Templates)
 
@@ -122,10 +124,10 @@ Show notification status summary with template-based formatting. Supports 13 tem
 **Severity Variable**:
 - `{{highest-severity}}` – Ordinal (1=critical, 2=error, 3=warning, 4=info)
 
-**Session/Window/Pane Variables** (reserved for future):
-- `{{session-list}}` – Sessions with active notifications
-- `{{window-list}}` – Windows with active notifications
-- `{{pane-list}}` – Panes with active notifications
+**Session/Window/Pane Variables**:
+- `{{session-list}}` – Sessions with active notifications (currently returns an empty string)
+- `{{window-list}}` – Windows with active notifications (currently returns an empty string)
+- `{{pane-list}}` – Panes with active notifications (currently returns an empty string except in special formats)
 
 #### Flags
 
@@ -179,6 +181,14 @@ set -g status-right "Inbox: #(tmux-intray status --format=count-only) %H:%M"
 
 - `0` - Success
 - `1` - Error (tmux not running, invalid template, or database error)
+
+### completion
+
+```bash
+tmux-intray completion [bash|zsh|fish|powershell]
+```
+
+Generates shell completion scripts using Cobra's built-in completion support.
 
 #### Full Documentation
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -76,6 +76,11 @@ export TMUX_INTRAY_RECENTS_TIME_WINDOW=6h
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `TMUX_INTRAY_HOOKS_DIR` | `$TMUX_INTRAY_CONFIG_DIR/hooks` | Directory containing hook scripts. |
+| `TMUX_INTRAY_HOOKS_FAILURE_MODE` | `warn` | Hook failure handling mode: `warn`, `ignore`, or `abort`. |
+| `TMUX_INTRAY_HOOKS_ASYNC` | `false` | Run hooks asynchronously (`1`/`true`) instead of synchronously. |
+| `TMUX_INTRAY_HOOKS_ASYNC_TIMEOUT` | `30` | Async hook timeout in seconds. |
+| `TMUX_INTRAY_MAX_HOOKS` | `10` | Maximum concurrent async hooks. |
+| `TMUX_INTRAY_HOOKS_VERBOSE` | `0` | Show framework-level hook execution logs when set to `1`. |
 
 ### Debugging & Logging
 
@@ -278,7 +283,7 @@ critical = "\u001b[0;31m"
 | `group_header.show_source_aggregation` | bool | Show aggregated pane/source info | `false` | `true`, `false` |
 | `group_header.badge_colors` | table | ANSI color codes per level (`info`, `warning`, `error`, `critical`) | defaults shown above | Strings containing ANSI escape sequences |
 
-`filters.read` lets you persist whether the TUI should show only read, only unread, or all notifications. At runtime you can toggle the same preference with the `:filter-read <read|unread|all>` command; the change is saved back to `tui.toml` automatically.
+`filters.read` lets you persist whether the TUI should show only read, only unread, or all notifications. There is no dedicated in-TUI command palette for changing this today; update the setting in `tui.toml` (or via future UI controls) and restart the TUI to apply it consistently.
 
 #### View Mode Migration
 
@@ -339,7 +344,7 @@ export TMUX_INTRAY_TUI_UNREAD_FIRST=false
 
 Set `group_by = "message"` to collapse identical notifications into a single group headed by the message text. Use `group_by = "pane_message"` if you want one unique message per pane (no duplicate rows under the group). You can do this in two ways:
 
-1. **Edit the settings file** – add `group_by = "message"` to `~/.config/tmux-intray/settings.toml` (or your `$XDG_CONFIG_HOME` variant) alongside your other preferences:
+1. **Edit the settings file** – add `group_by = "message"` to `~/.config/tmux-intray/tui.toml` (or your `$XDG_CONFIG_HOME` variant) alongside your other preferences:
 
     ```toml
     view_mode = "grouped"
@@ -347,7 +352,7 @@ Set `group_by = "message"` to collapse identical notifications into a single gro
     default_expand_level = 1
     ```
 
-2. **Use the TUI command palette** – run `:group-by message` inside the TUI; the change is saved automatically on exit or when you run `:w`.
+2. **Edit the TUI settings file** – set `group_by = "message"` in `tui.toml`, then restart the TUI.
 
 Message grouping keeps all other filters intact and works with CLI commands such as `tmux-intray list --group-by=message` and `tmux-intray list --group-by=message --group-count`.
 
@@ -390,8 +395,8 @@ critical = "\u001b[0;31m"
 
 Settings are saved automatically in these situations:
 
-1. **On TUI exit** (pressing `q`, `:q`, or `Ctrl+C`)
-2. **Manual save** (pressing `:w`)
+1. **On TUI exit** (pressing `q` or `Ctrl+C`)
+2. **When switching tabs inside the TUI** (for example via `r`, `a`, `Ctrl+r`, `Ctrl+a`, or `Ctrl+s`)
 
 The save operation uses atomic writes to prevent file corruption.
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -316,7 +316,7 @@ which tmux-intray
 export PATH="$HOME/.local/bin:$PATH"
 
 # 3. Verify installation
-tmux-intray version  # or appropriate version command
+tmux-intray --version
 ```
 
 **Debug**:

--- a/docs/design/go-package-structure.md
+++ b/docs/design/go-package-structure.md
@@ -33,12 +33,9 @@ github.com/cristianoliveira/tmux-intray/
 │   ├── jump.go                # Jump command
 │   ├── status.go              # Status command
 │   ├── follow.go              # Follow command
-│   ├── help.go                # Help command
-│   ├── version.go             # Version command
 │   ├── cleanup.go             # Cleanup command
 │   ├── root.go                # Root command and CLI entry point
-│   └── wrapper/               # Wrapper for Bash migration
-│       └── main.go
+│   └── main.go                # CLI executable entry point
 ├── internal/                  # Private application code
 │   ├── core/                  # Core tmux interaction & tray management
 │   │   ├── core.go

--- a/docs/design/tui/tui-guidelines.md
+++ b/docs/design/tui/tui-guidelines.md
@@ -161,7 +161,7 @@ type CommandService interface {
 }
 ```
 
-This interface enables extensible command handling within the TUI, supporting commands like `:q`, `:w`, `:group-by`.
+This interface sketches a possible future extension point for richer in-TUI commands. The current public TUI does not expose a `:` command palette.
 
 ### 5. RuntimeCoordinator Interface
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -16,8 +16,8 @@ tmux-intray supports the following hook points:
 | `post-add` | After a notification is successfully added | Trigger external alerts (Slack, email), log to external systems, update dashboards |
 | `pre-dismiss` | Before a notification is dismissed | Confirm dismissal, check conditions, backup before removal |
 | `post-dismiss` | After a notification is dismissed | Clean up related resources, update external systems, trigger follow-up actions |
-| `cleanup` | After garbage collection runs | Archive old notifications, update metrics, perform maintenance |
-| `post-list` | After listing notifications (planned) | Audit logging, analytics, usage tracking |
+| `cleanup` | Before garbage collection removes old notifications | Archive old notifications, update metrics, perform maintenance |
+| `post-cleanup` | After garbage collection finishes | Record deleted count, update metrics, archive summaries |
 
 ## Hook Script Location
 
@@ -162,10 +162,9 @@ TMUX_INTRAY_HOOKS_VERBOSE=1 tmux-intray add "message"
 export TMUX_INTRAY_HOOKS_VERBOSE=1
 ```
 
-**Per-session (in config file)**:
+**Per-session (via environment or shell profile)**:
 ```bash
-# In ~/.config/tmux-intray/config.sh
-TMUX_INTRAY_HOOKS_VERBOSE=1
+export TMUX_INTRAY_HOOKS_VERBOSE=1
 ```
 
 ## Configuration
@@ -173,13 +172,26 @@ TMUX_INTRAY_HOOKS_VERBOSE=1
 Hooks are configured via environment variables or the configuration file:
 
 ```bash
-# In ~/.config/tmux-intray/config.sh
+# Hook directory (default: $TMUX_INTRAY_CONFIG_DIR/hooks)
+export TMUX_INTRAY_HOOKS_DIR="$HOME/.config/tmux-intray/hooks"
 
-# Enable verbose output for hooks (0=silent, 1=verbose)
-TMUX_INTRAY_HOOKS_VERBOSE=0
+# Failure mode: warn (default), ignore, abort
+export TMUX_INTRAY_HOOKS_FAILURE_MODE=warn
+
+# Async execution: 0/1 or false/true
+export TMUX_INTRAY_HOOKS_ASYNC=0
+
+# Async timeout in seconds (default: 30)
+export TMUX_INTRAY_HOOKS_ASYNC_TIMEOUT=30
+
+# Max concurrent async hooks (default: 10)
+export TMUX_INTRAY_MAX_HOOKS=10
+
+# Verbose framework logging for hook execution (0=silent, 1=verbose)
+export TMUX_INTRAY_HOOKS_VERBOSE=0
 ```
 
-**Note:** Hooks are enabled by the presence of script files in the hook directories. Remove or rename hook scripts in the hook directory to disable specific hooks.
+**Note:** Hooks are enabled by the presence of executable script files in the hook directories. Remove, rename, or make scripts non-executable to disable specific hooks.
 
 ## Example Use Cases
 
@@ -586,7 +598,7 @@ To use any of these notification hook examples:
    chmod +x ~/.config/tmux-intray/hooks/pre-add/*.sh
    ```
 
-4. **Configure (optional)** - Set environment variables in `~/.config/tmux-intray/config.sh` or export in your shell:
+4. **Configure (optional)** - Export environment variables in your shell profile or current shell:
    ```bash
    export MACOS_SOUND_FILE="/System/Library/Sounds/Glass.aiff"
    export TMUX_NOTIFICATION_DURATION=5000

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -8,7 +8,6 @@ These are tmux prefix bindings installed by `tmux-intray.tmux`:
 
 | Shortcut | Context | Action |
 |---|---|---|
-| `prefix + I` | tmux | Run `tmux-intray follow` |
 | `prefix + J` | tmux | Open `tmux-intray tui` in a tmux popup |
 
 ## TUI shortcuts (normal mode)
@@ -29,8 +28,9 @@ Applies when the TUI is open and not in search input or confirmation mode.
 | `a` | Switch tab to All | |
 | `Ctrl+r` | Switch tab to Recents | Works in all views |
 | `Ctrl+a` | Switch tab to All | Works in all views |
+| `Ctrl+s` | Switch tab to Sessions | Works in all views |
 | `/` | Enter search input mode | |
-| `v` | Cycle view mode | `detailed -> grouped -> search -> detailed` |
+| `Ctrl+v` | Cycle view mode | `detailed -> grouped -> search -> detailed` |
 | `?` | Toggle help text | |
 | `q` | Quit TUI | Saves settings before quitting |
 | `Esc` | Quit TUI | If not in search input |
@@ -74,7 +74,7 @@ Examples:
 When view mode is `search` but search input is not active, normal keybindings still work, including:
 - `j` / `k`, `gg`, `G`
 - `d`, `R`, `u`, `Enter`, `q`, `?`, `/`
-- `v` (cycle view mode)
+- `Ctrl+v` (cycle view mode)
 
 ## Confirmation dialog mode
 
@@ -88,7 +88,9 @@ Confirmation mode is used for destructive grouped actions (for example, `D` on a
 | `Esc` | Cancel action |
 | `Ctrl+c` | Cancel and quit TUI |
 
-## Not shortcuts
+## Arrow keys
 
-The following keys are currently handled as no-op and are intentionally not navigation shortcuts:
-- `Up` / `Down` arrow keys
+Arrow keys are supported in search contexts:
+- `Up` / `Down` move selection while search input is active or when using search view mode
+
+Outside search contexts, `j` / `k` remain the primary documented navigation keys.

--- a/docs/status-guide.md
+++ b/docs/status-guide.md
@@ -50,7 +50,7 @@ tmux-intray status --format='C:{{critical-count}} E:{{error-count}} W:{{warning-
 
 ## Variables Reference
 
-All 13 available variables:
+The status formatter exposes 13 core variables plus 4 severity-count variables.
 
 ### Count Variables
 
@@ -97,15 +97,15 @@ All 13 available variables:
 - `3` - At least one **warning** (no critical/error)
 - `4` - All are **info** (or no notifications)
 
-### Session/Window/Pane Variables (Future)
+### Session/Window/Pane Variables
 
-These variables are reserved for future implementation and currently return empty strings:
+These variables are recognized by the formatter. Today they return empty strings in normal template rendering:
 
-| Variable | Status |
-|----------|--------|
-| `{{session-list}}` | Reserved |
-| `{{window-list}}` | Reserved |
-| `{{pane-list}}` | Reserved |
+| Variable | Current behavior |
+|----------|------------------|
+| `{{session-list}}` | Empty string |
+| `{{window-list}}` | Empty string |
+| `{{pane-list}}` | Empty string |
 
 ## Presets
 
@@ -130,6 +130,8 @@ Presets are built-in templates for common use cases. Use `--format=preset-name`.
 ### 3. `json`
 
 **Special format** - Returns structured JSON with all counts and pane breakdown.
+
+> Note: although `json` also exists in the template preset registry, the `status` command handles `json` as a dedicated special format before template expansion.
 
 **Output example**:
 ```json
@@ -162,6 +164,8 @@ Presets are built-in templates for common use cases. Use `--format=preset-name`.
 
 **Special format** - Shows counts for each severity level.
 
+> Note: although `levels` also exists in the template preset registry, the `status` command handles it as a dedicated special format before template expansion.
+
 **Output example**:
 ```
 info:77
@@ -180,6 +184,8 @@ tmux-intray status --format='Severity: {{highest-severity}} | Unread: {{unread-c
 ### 6. `panes`
 
 **Special format** - Shows pane counts sorted by pane identifier.
+
+> Note: although `panes` also exists in the template preset registry, the `status` command handles it as a dedicated special format before template expansion.
 
 **Output example**:
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -134,7 +134,7 @@ $EDITOR advanced-filtering.md
 ./ci-pipeline.sh "MyProject"
 
 # View advanced filtering examples
-cat advanced-filtering.sh
+cat advanced-filtering.md
 ```
 
 ## Customization
@@ -143,7 +143,7 @@ All examples are designed to be modified for your needs:
 
 - **Change messages**: Edit notification text to match your use case
 - **Add filters**: Use `--level`, `--session`, `--pane` flags
-- **Custom formats**: Use `--format` flag with templates
+- **Custom formats**: Use `tmux-intray status --format` with templates
 - **Integrate**: Combine with other tools (`jq`, `fzf`, `awk`)
 
 ## Related Documentation

--- a/examples/hooks/README.md
+++ b/examples/hooks/README.md
@@ -17,27 +17,26 @@ tmux-intray provides a hook system that allows you to execute custom scripts at 
 
 ## Configuration
 
-Hooks are configured via environment variables (set in your shell profile or config file):
+Hooks are configured via environment variables (set in your shell profile or current shell):
 
 ```bash
-# Enable hooks globally
-TMUX_INTRAY_HOOKS_ENABLED=1
-
-# Hook failure mode: ignore, warn, abort
-TMUX_INTRAY_HOOKS_FAILURE_MODE="warn"
+# Hook failure mode: warn (default), ignore, abort
+export TMUX_INTRAY_HOOKS_FAILURE_MODE="warn"
 
 # Run hooks asynchronously (0=sync, 1=async)
-TMUX_INTRAY_HOOKS_ASYNC=0
+export TMUX_INTRAY_HOOKS_ASYNC=0
+
+# Async timeout in seconds (default: 30)
+export TMUX_INTRAY_HOOKS_ASYNC_TIMEOUT=30
+
+# Maximum concurrent async hooks (default: 10)
+export TMUX_INTRAY_MAX_HOOKS=10
 
 # Hook directory (default: $TMUX_INTRAY_CONFIG_DIR/hooks)
-TMUX_INTRAY_HOOKS_DIR="$HOME/.config/tmux-intray/hooks"
-
-# Per-hook enable/disable
-TMUX_INTRAY_HOOKS_ENABLED_pre_add=1
-TMUX_INTRAY_HOOKS_ENABLED_post_add=1
+export TMUX_INTRAY_HOOKS_DIR="$HOME/.config/tmux-intray/hooks"
 ```
 
-**Note**: Hooks can also be configured via TOML in `~/.config/tmux-intray/config.toml`. See [Configuration Guide](../../docs/configuration.md) for details.
+**Note**: Hooks are discovered from the hook directory; there is no separate global enable toggle in normal runtime behavior. See [Configuration Guide](../../docs/configuration.md) and [Hooks Guide](../../docs/hooks.md) for details.
 
 ## Example Scripts
 
@@ -72,15 +71,10 @@ Plays a sound on Linux without displaying any UI notification. Uses `paplay` (Pu
    chmod +x ~/.config/tmux-intray/hooks/*/*.sh
    ```
 
-3. Enable hooks in your config:
+3. Configure hook behavior if needed:
    ```bash
-   # Via environment variable
-   export TMUX_INTRAY_HOOKS_ENABLED=1
-
-   # Or via config.toml
-   # Add to ~/.config/tmux-intray/config.toml:
-   # [hooks]
-   # enabled = true
+   export TMUX_INTRAY_HOOKS_FAILURE_MODE=warn
+   export TMUX_INTRAY_HOOKS_ASYNC=0
    ```
 
 4. Customize scripts as needed.

--- a/internal/app/add_test.go
+++ b/internal/app/add_test.go
@@ -1,0 +1,198 @@
+package app
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+type fakeAddClient struct {
+	ensureTmuxRunningResult bool
+	ensureCalls             int
+	addCalled               bool
+	addErr                  error
+	captured                struct {
+		message     string
+		session     string
+		window      string
+		pane        string
+		paneCreated string
+		noAssociate bool
+		level       string
+	}
+}
+
+func (f *fakeAddClient) EnsureTmuxRunning() bool {
+	f.ensureCalls++
+	return f.ensureTmuxRunningResult
+}
+
+func (f *fakeAddClient) AddTrayItem(item, session, window, pane, paneCreated string, noAssociate bool, level string) (string, error) {
+	f.addCalled = true
+	f.captured.message = item
+	f.captured.session = session
+	f.captured.window = window
+	f.captured.pane = pane
+	f.captured.paneCreated = paneCreated
+	f.captured.noAssociate = noAssociate
+	f.captured.level = level
+	return "", f.addErr
+}
+
+func TestNewAddUseCasePanicsWhenClientIsNil(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatalf("expected panic, got nil")
+		}
+		msg, ok := r.(string)
+		if !ok {
+			t.Fatalf("expected string panic, got %T", r)
+		}
+		if !strings.Contains(msg, "client dependency cannot be nil") {
+			t.Fatalf("unexpected panic message: %q", msg)
+		}
+	}()
+
+	NewAddUseCase(nil)
+}
+
+func TestValidateAddMessage(t *testing.T) {
+	tests := []struct {
+		name        string
+		message     string
+		wantErr     bool
+		errContains string
+	}{
+		{name: "empty", message: "", wantErr: true, errContains: "message cannot be empty"},
+		{name: "whitespace only", message: " \n\t ", wantErr: true, errContains: "message cannot be empty"},
+		{name: "single character", message: "a", wantErr: false},
+		{name: "trimmed but valid", message: "  hello world  ", wantErr: false},
+		{name: "exactly max length", message: strings.Repeat("a", 1000), wantErr: false},
+		{name: "over max length", message: strings.Repeat("a", 1001), wantErr: true, errContains: "message too long"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateAddMessage(tt.message)
+			if tt.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if tt.errContains != "" && (err == nil || !strings.Contains(err.Error(), tt.errContains)) {
+				t.Fatalf("expected error containing %q, got %v", tt.errContains, err)
+			}
+		})
+	}
+}
+
+func TestAddUseCaseExecuteRejectsEmptyMessage(t *testing.T) {
+	client := &fakeAddClient{ensureTmuxRunningResult: true}
+	useCase := NewAddUseCase(client)
+
+	err := useCase.Execute(AddInput{Args: []string{}})
+	if err == nil || !strings.Contains(err.Error(), "message cannot be empty") {
+		t.Fatalf("expected validation error, got %v", err)
+	}
+	if client.addCalled {
+		t.Fatalf("expected AddTrayItem not to be called")
+	}
+}
+
+func TestAddUseCaseExecuteRequiresTmuxWhenAutoAssociating(t *testing.T) {
+	client := &fakeAddClient{ensureTmuxRunningResult: false}
+	useCase := NewAddUseCase(client)
+
+	err := useCase.Execute(AddInput{
+		Args:    []string{"hello"},
+		Session: "   ",
+		Window:  "\t",
+		Pane:    "\n",
+	})
+	if err == nil || !strings.Contains(err.Error(), "tmux not running") {
+		t.Fatalf("expected tmux not running error, got %v", err)
+	}
+	if client.ensureCalls != 1 {
+		t.Fatalf("expected EnsureTmuxRunning once, got %d", client.ensureCalls)
+	}
+	if client.addCalled {
+		t.Fatalf("expected AddTrayItem not to be called")
+	}
+}
+
+func TestAddUseCaseExecuteAllowsTmuxlessFallback(t *testing.T) {
+	client := &fakeAddClient{ensureTmuxRunningResult: false}
+	useCase := NewAddUseCase(client)
+
+	err := useCase.Execute(AddInput{
+		Args: []string{"hello"},
+		AllowTmuxless: func() bool {
+			return true
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if client.ensureCalls != 1 {
+		t.Fatalf("expected EnsureTmuxRunning once, got %d", client.ensureCalls)
+	}
+	if !client.addCalled {
+		t.Fatalf("expected AddTrayItem to be called")
+	}
+	if !client.captured.noAssociate {
+		t.Fatalf("expected noAssociate=true in tmuxless fallback")
+	}
+}
+
+func TestAddUseCaseExecuteSkipsTmuxForNoAssociateAndWrapsError(t *testing.T) {
+	client := &fakeAddClient{ensureTmuxRunningResult: false, addErr: errors.New("boom")}
+	useCase := NewAddUseCase(client)
+
+	err := useCase.Execute(AddInput{
+		Args:        []string{"hello", "world"},
+		Session:     " sess-1 ",
+		Window:      " win-2 ",
+		Pane:        " pane-3 ",
+		PaneCreated: "1700000000",
+		NoAssociate: true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "add: failed to add tray item: boom") {
+		t.Fatalf("expected wrapped add error, got %v", err)
+	}
+	if client.ensureCalls != 0 {
+		t.Fatalf("expected EnsureTmuxRunning not to be called, got %d", client.ensureCalls)
+	}
+	if client.captured.message != "hello world" {
+		t.Fatalf("expected joined message, got %q", client.captured.message)
+	}
+	if client.captured.session != "sess-1" || client.captured.window != "win-2" || client.captured.pane != "pane-3" {
+		t.Fatalf("expected trimmed context, got session=%q window=%q pane=%q", client.captured.session, client.captured.window, client.captured.pane)
+	}
+	if client.captured.paneCreated != "1700000000" {
+		t.Fatalf("expected paneCreated to pass through, got %q", client.captured.paneCreated)
+	}
+	if !client.captured.noAssociate {
+		t.Fatalf("expected noAssociate=true")
+	}
+	if client.captured.level != "info" {
+		t.Fatalf("expected default level info, got %q", client.captured.level)
+	}
+}
+
+func TestAddUseCaseExecuteUsesExplicitLevel(t *testing.T) {
+	client := &fakeAddClient{ensureTmuxRunningResult: true}
+	useCase := NewAddUseCase(client)
+
+	err := useCase.Execute(AddInput{
+		Args:  []string{"hello"},
+		Level: "warning",
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if client.captured.level != "warning" {
+		t.Fatalf("expected warning level, got %q", client.captured.level)
+	}
+}

--- a/internal/app/list_test.go
+++ b/internal/app/list_test.go
@@ -1,0 +1,162 @@
+package app
+
+import (
+	"bytes"
+	"errors"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/cristianoliveira/tmux-intray/internal/domain"
+	"github.com/cristianoliveira/tmux-intray/internal/search"
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeListClient struct {
+	result string
+	err    error
+	calls  []struct {
+		state      string
+		level      string
+		session    string
+		window     string
+		pane       string
+		olderThan  string
+		newerThan  string
+		readFilter string
+	}
+}
+
+func (f *fakeListClient) ListNotifications(state, level, session, window, pane, olderThanCutoff, newerThanCutoff, readFilter string) (string, error) {
+	f.calls = append(f.calls, struct {
+		state      string
+		level      string
+		session    string
+		window     string
+		pane       string
+		olderThan  string
+		newerThan  string
+		readFilter string
+	}{
+		state:      state,
+		level:      level,
+		session:    session,
+		window:     window,
+		pane:       pane,
+		olderThan:  olderThanCutoff,
+		newerThan:  newerThanCutoff,
+		readFilter: readFilter,
+	})
+	return f.result, f.err
+}
+
+func testLines() string {
+	return `1	2025-01-01T10:00:00Z	active	sess1	win1	pane1	message one	123	info	2025-01-01T10:05:00Z
+2	2025-01-01T11:00:00Z	active	sess1	win1	pane2	message two	124	warning	
+3	2025-01-01T12:00:00Z	dismissed	sess2	win2	pane3	message three	125	error	2025-01-01T12:05:00Z
+4	2025-01-01T13:00:00Z	active	sess2	win2	pane4	message four	126	info	
+5	2025-01-01T14:00:00Z	active	sess3	win3	pane5	message five	127	info	2025-01-01T14:05:00Z`
+}
+
+func TestListUseCaseExecuteEmpty(t *testing.T) {
+	client := &fakeListClient{result: ""}
+	useCase := NewListUseCase(client)
+
+	var buf bytes.Buffer
+	useCase.Execute(ListOptions{Format: "simple"}, &buf)
+
+	assert.Equal(t, "\033[0;34mNo notifications found\033[0m\n", buf.String())
+}
+
+func TestListUseCaseExecuteClientError(t *testing.T) {
+	client := &fakeListClient{err: errors.New("storage error")}
+	useCase := NewListUseCase(client)
+
+	var buf bytes.Buffer
+	useCase.Execute(ListOptions{}, &buf)
+
+	assert.Contains(t, buf.String(), "list: failed to list notifications: storage error")
+}
+
+func TestListUseCaseExecuteUnreadFirstOrdering(t *testing.T) {
+	client := &fakeListClient{result: testLines()}
+	useCase := NewListUseCase(client)
+
+	var buf bytes.Buffer
+	useCase.Execute(ListOptions{Format: "simple"}, &buf)
+
+	output := strings.TrimSpace(buf.String())
+	var ids []int
+	for _, line := range strings.Split(output, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		id, err := strconv.Atoi(fields[0])
+		if err != nil {
+			t.Fatalf("failed to parse ID from line %q: %v", line, err)
+		}
+		ids = append(ids, id)
+	}
+
+	assert.Equal(t, []int{2, 4, 1, 3, 5}, ids)
+}
+
+func TestListUseCaseExecuteWithCustomSearchProvider(t *testing.T) {
+	client := &fakeListClient{result: "1\t2025-01-01T10:00:00Z\tactive\tsess1\twin1\tpane1\terror message\t123\terror\n" +
+		"2\t2025-01-01T11:00:00Z\tactive\tsess1\twin1\tpane2\twarning message\t124\twarning\n"}
+	useCase := NewListUseCase(client)
+
+	var buf bytes.Buffer
+	provider := search.NewSubstringProvider(search.WithFields([]string{"level"}))
+	useCase.Execute(ListOptions{
+		Search:         "error",
+		SearchProvider: provider,
+		Format:         "legacy",
+	}, &buf)
+
+	assert.Contains(t, buf.String(), "error message")
+	assert.NotContains(t, buf.String(), "warning message")
+}
+
+func TestListUseCaseFetchesThroughClient(t *testing.T) {
+	client := &fakeListClient{result: testLines()}
+	useCase := NewListUseCase(client)
+
+	var buf bytes.Buffer
+	useCase.Execute(ListOptions{
+		State:      "active",
+		Level:      "warning",
+		Session:    "sess1",
+		Window:     "win1",
+		Pane:       "pane2",
+		OlderThan:  "2026-01-01T00:00:00Z",
+		NewerThan:  "2026-01-02T00:00:00Z",
+		ReadFilter: "unread",
+		Format:     "simple",
+	}, &buf)
+
+	if assert.Len(t, client.calls, 1) {
+		call := client.calls[0]
+		assert.Equal(t, "active", call.state)
+		assert.Equal(t, "warning", call.level)
+		assert.Equal(t, "sess1", call.session)
+		assert.Equal(t, "win1", call.window)
+		assert.Equal(t, "pane2", call.pane)
+		assert.Equal(t, "2026-01-01T00:00:00Z", call.olderThan)
+		assert.Equal(t, "2026-01-02T00:00:00Z", call.newerThan)
+		assert.Equal(t, "unread", call.readFilter)
+	}
+}
+
+func TestOrderUnreadFirstPreservesRelativeOrder(t *testing.T) {
+	notifs := []*domain.Notification{
+		{ID: 1, ReadTimestamp: "2025-01-01T10:00:00Z", State: domain.StateActive, Level: domain.LevelInfo, Message: "test1", Timestamp: "2025-01-01T10:00:00Z"},
+		{ID: 2, ReadTimestamp: "", State: domain.StateActive, Level: domain.LevelInfo, Message: "test2", Timestamp: "2025-01-01T11:00:00Z"},
+		{ID: 3, ReadTimestamp: "2025-01-01T11:00:00Z", State: domain.StateActive, Level: domain.LevelInfo, Message: "test3", Timestamp: "2025-01-01T12:00:00Z"},
+		{ID: 4, ReadTimestamp: "", State: domain.StateActive, Level: domain.LevelInfo, Message: "test4", Timestamp: "2025-01-01T13:00:00Z"},
+	}
+
+	result := OrderUnreadFirst(notifs)
+	assert.Equal(t, []*domain.Notification{notifs[1], notifs[3], notifs[0], notifs[2]}, result)
+}

--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -5,7 +5,9 @@ import (
 	"io"
 	"strings"
 
+	"github.com/cristianoliveira/tmux-intray/internal/domain"
 	"github.com/cristianoliveira/tmux-intray/internal/format"
+	"github.com/cristianoliveira/tmux-intray/internal/formatter"
 )
 
 // StatusClient defines dependencies for status command.
@@ -35,28 +37,12 @@ func DetermineStatusFormat(formatFlag, envFormat string, flagChanged bool) strin
 		result = envFormat
 	}
 	if result == "" {
-		result = "summary"
+		result = "compact"
 	}
 	return result
 }
 
-// ValidateStatusFormat validates status output format.
-func ValidateStatusFormat(formatValue string) error {
-	validFormats := map[string]bool{
-		"summary": true,
-		"levels":  true,
-		"panes":   true,
-		"json":    true,
-	}
-
-	if !validFormats[formatValue] {
-		return fmt.Errorf("status: unknown format: %s", formatValue)
-	}
-
-	return nil
-}
-
-// Execute runs status behavior for a validated format.
+// Execute runs status behavior for presets, legacy formats, and custom templates.
 func (u *StatusUseCase) Execute(formatValue string, w io.Writer) error {
 	if !u.client.EnsureTmuxRunning() {
 		return fmt.Errorf("tmux not running")
@@ -71,9 +57,14 @@ func (u *StatusUseCase) Execute(formatValue string, w io.Writer) error {
 		return formatPanes(u.client, w)
 	case "json":
 		return formatJSON(u.client, w)
-	default:
-		return fmt.Errorf("status: unknown format: %s", formatValue)
 	}
+
+	registry := formatter.NewPresetRegistry()
+	if preset, err := registry.Get(formatValue); err == nil {
+		return runStatusWithTemplate(u.client, preset.Template, w)
+	}
+
+	return runStatusWithTemplate(u.client, formatValue, w)
 }
 
 // CountByState counts notifications for a state.
@@ -112,6 +103,62 @@ func PaneCounts(client StatusClient) map[string]int {
 	}
 
 	return format.ParsePaneCounts(lines)
+}
+
+func buildVariableContext(client StatusClient) formatter.VariableContext {
+	active := CountByState(client, "active")
+	dismissed := CountByState(client, "dismissed")
+	read := CountByState(client, "dismissed")
+	infoCount, warningCount, errCount, criticalCount := CountByLevel(client)
+
+	latestMsg := ""
+	lines, _ := client.ListNotifications("active", "", "", "", "", "", "", "")
+	if lines != "" {
+		fields := strings.Split(strings.Split(lines, "\n")[0], "\t")
+		if len(fields) > 6 {
+			latestMsg = fields[6]
+		}
+	}
+
+	highestSeverity := domain.LevelInfo
+	if criticalCount > 0 {
+		highestSeverity = domain.LevelCritical
+	} else if errCount > 0 {
+		highestSeverity = domain.LevelError
+	} else if warningCount > 0 {
+		highestSeverity = domain.LevelWarning
+	}
+
+	return formatter.VariableContext{
+		UnreadCount:     active,
+		TotalCount:      active,
+		ReadCount:       read,
+		ActiveCount:     active,
+		DismissedCount:  dismissed,
+		InfoCount:       infoCount,
+		WarningCount:    warningCount,
+		ErrorCount:      errCount,
+		CriticalCount:   criticalCount,
+		LatestMessage:   latestMsg,
+		HasUnread:       active > 0,
+		HasActive:       active > 0,
+		HasDismissed:    dismissed > 0,
+		HighestSeverity: highestSeverity,
+		SessionList:     "",
+		WindowList:      "",
+		PaneList:        "",
+	}
+}
+
+func runStatusWithTemplate(client StatusClient, template string, w io.Writer) error {
+	ctx := buildVariableContext(client)
+	engine := formatter.NewTemplateEngine()
+	result, err := engine.Substitute(template, ctx)
+	if err != nil {
+		return fmt.Errorf("template substitution error: %w", err)
+	}
+	_, err = fmt.Fprintln(w, result)
+	return err
 }
 
 func formatSummary(client StatusClient, w io.Writer) error {

--- a/internal/app/status_test.go
+++ b/internal/app/status_test.go
@@ -1,0 +1,149 @@
+package app
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func statusMockLines() string {
+	return `1	2025-01-01T10:00:00Z	active	sess1	win1	pane1	message one	123	info
+2	2025-01-01T11:00:00Z	active	sess1	win1	pane2	message two	124	warning
+3	2025-01-01T12:00:00Z	dismissed	sess2	win2	pane3	message three	125	error
+4	2025-01-01T13:00:00Z	active	sess2	win2	pane4	message four	126	info
+5	2025-01-01T14:00:00Z	active	sess3	win3	pane5	message five	127	critical`
+}
+
+type fakeStatusClient struct {
+	ensureTmuxRunningResult bool
+	ensureCalls             int
+	listNotificationsResult string
+	listNotificationsErr    error
+}
+
+func (f *fakeStatusClient) EnsureTmuxRunning() bool {
+	f.ensureCalls++
+	return f.ensureTmuxRunningResult
+}
+
+func (f *fakeStatusClient) ListNotifications(stateFilter, levelFilter, sessionFilter, windowFilter, paneFilter, olderThanCutoff, newerThanCutoff, readFilter string) (string, error) {
+	lines := strings.Split(f.listNotificationsResult, "\n")
+	var filtered []string
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		fields := strings.Split(line, "\t")
+		if stateFilter != "" && stateFilter != "all" && len(fields) > 2 && fields[2] != stateFilter {
+			continue
+		}
+		filtered = append(filtered, line)
+	}
+	return strings.Join(filtered, "\n"), f.listNotificationsErr
+}
+
+func TestDetermineStatusFormat(t *testing.T) {
+	tests := []struct {
+		name        string
+		formatFlag  string
+		envFormat   string
+		flagChanged bool
+		want        string
+	}{
+		{name: "flag wins when changed", formatFlag: "compact", envFormat: "json", flagChanged: true, want: "compact"},
+		{name: "env used when flag unchanged", formatFlag: "compact", envFormat: "json", flagChanged: false, want: "json"},
+		{name: "default compact when empty", formatFlag: "", envFormat: "", flagChanged: false, want: "compact"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DetermineStatusFormat(tt.formatFlag, tt.envFormat, tt.flagChanged)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestStatusUseCaseExecuteCompactPreset(t *testing.T) {
+	client := &fakeStatusClient{ensureTmuxRunningResult: true, listNotificationsResult: statusMockLines()}
+	useCase := NewStatusUseCase(client)
+	var buf bytes.Buffer
+
+	err := useCase.Execute("compact", &buf)
+	require.NoError(t, err)
+	assert.Equal(t, "[4] message one\n", buf.String())
+}
+
+func TestStatusUseCaseExecuteDetailedPreset(t *testing.T) {
+	client := &fakeStatusClient{ensureTmuxRunningResult: true, listNotificationsResult: statusMockLines()}
+	useCase := NewStatusUseCase(client)
+	var buf bytes.Buffer
+
+	err := useCase.Execute("detailed", &buf)
+	require.NoError(t, err)
+	assert.Equal(t, "4 unread, 1 read | Latest: message one\n", buf.String())
+}
+
+func TestStatusUseCaseExecuteLegacyFormats(t *testing.T) {
+	tests := []struct {
+		format string
+		want   string
+	}{
+		{format: "summary", want: "Active notifications: 4\n  info: 2, warning: 1, error: 0, critical: 1\n"},
+		{format: "levels", want: "info:2\nwarning:1\nerror:0\ncritical:1\n"},
+		{format: "panes", want: "sess1:win1:pane1:1\nsess1:win1:pane2:1\nsess2:win2:pane4:1\nsess3:win3:pane5:1\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.format, func(t *testing.T) {
+			client := &fakeStatusClient{ensureTmuxRunningResult: true, listNotificationsResult: statusMockLines()}
+			useCase := NewStatusUseCase(client)
+			var buf bytes.Buffer
+
+			err := useCase.Execute(tt.format, &buf)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, buf.String())
+		})
+	}
+}
+
+func TestStatusUseCaseExecuteCustomTemplate(t *testing.T) {
+	client := &fakeStatusClient{ensureTmuxRunningResult: true, listNotificationsResult: statusMockLines()}
+	useCase := NewStatusUseCase(client)
+	var buf bytes.Buffer
+
+	err := useCase.Execute("{{critical-count}}|{{unread-count}}|{{latest-message}}", &buf)
+	require.NoError(t, err)
+	assert.Equal(t, "1|4|message one\n", buf.String())
+}
+
+func TestStatusUseCaseExecuteTmuxNotRunning(t *testing.T) {
+	client := &fakeStatusClient{ensureTmuxRunningResult: false}
+	useCase := NewStatusUseCase(client)
+	var buf bytes.Buffer
+
+	err := useCase.Execute("compact", &buf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tmux not running")
+	assert.Equal(t, 1, client.ensureCalls)
+}
+
+func TestStatusCountHelpers(t *testing.T) {
+	client := &fakeStatusClient{ensureTmuxRunningResult: true, listNotificationsResult: statusMockLines()}
+
+	assert.Equal(t, 4, CountByState(client, "active"))
+	assert.Equal(t, 1, CountByState(client, "dismissed"))
+
+	info, warning, errCount, critical := CountByLevel(client)
+	assert.Equal(t, 2, info)
+	assert.Equal(t, 1, warning)
+	assert.Equal(t, 0, errCount)
+	assert.Equal(t, 1, critical)
+
+	panes := PaneCounts(client)
+	assert.Len(t, panes, 4)
+	assert.Equal(t, 1, panes["sess1:win1:pane1"])
+	assert.Equal(t, 1, panes["sess3:win3:pane5"])
+}

--- a/internal/tui/render/render.go
+++ b/internal/tui/render/render.go
@@ -164,7 +164,7 @@ func buildFullHelpSearchModeItems(state FooterState) []string {
 	items = append(items, fmt.Sprintf("read: %s", readFilterIndicator(state.ReadFilter)))
 	items = append(items, "ESC: exit search")
 	if state.ViewMode == settings.ViewModeSearch {
-		items = append(items, "v: cycle view mode")
+		items = append(items, "Ctrl+v: cycle view mode")
 	}
 	items = append(items, "Ctrl+j/k: navigate")
 	items = append(items, "j/k: move")
@@ -189,7 +189,7 @@ func buildFullHelpNormalModeItems(state FooterState) []string {
 	items = append(items, "j/k: move")
 	items = append(items, "gg/G: top/bottom")
 	items = append(items, "/: search messages")
-	items = append(items, "v: cycle view mode")
+	items = append(items, "Ctrl+v: cycle view mode")
 	if state.Grouped {
 		items = append(items, "h/l: collapse/expand")
 		items = append(items, "za: toggle fold")
@@ -216,7 +216,7 @@ func buildMinimalSearchModeItems(state FooterState) []string {
 	items = append(items, "ESC: exit search")
 	items = append(items, "Ctrl+j/k: navigate")
 	if state.ViewMode == settings.ViewModeSearch {
-		items = append(items, "v: cycle view mode")
+		items = append(items, "Ctrl+v: cycle view mode")
 	}
 	items = append(items, fmt.Sprintf("mode: %s", viewModeIndicator(state.ViewMode)))
 	items = append(items, "?: toggle help")

--- a/internal/tui/render/render_test.go
+++ b/internal/tui/render/render_test.go
@@ -259,7 +259,7 @@ func TestFooterGroupedHelpText(t *testing.T) {
 	assert.Contains(t, footer, "Ctrl+a: all")
 	assert.Contains(t, footer, "Ctrl+s: sessions")
 	assert.Contains(t, footer, "read: all")
-	assert.Contains(t, footer, "v: cycle view mode")
+	assert.Contains(t, footer, "Ctrl+v: cycle view mode")
 	assert.Contains(t, footer, "gg/G: top/bottom")
 	assert.Contains(t, footer, "h/l: collapse/expand")
 	assert.Contains(t, footer, "za: toggle fold")
@@ -288,7 +288,7 @@ func TestFooterSearchViewModeHelpTextShowsJumpOnEnter(t *testing.T) {
 	assert.Contains(t, footer, "mode: [S]")
 	assert.Contains(t, footer, "ESC: exit search")
 	assert.Contains(t, footer, "Ctrl+j/k: navigate")
-	assert.Contains(t, footer, "v: cycle view mode")
+	assert.Contains(t, footer, "Ctrl+v: cycle view mode")
 	assert.Contains(t, footer, "Enter: jump")
 	assert.NotContains(t, footer, "Enter: exit search")
 }
@@ -325,7 +325,7 @@ func TestFooterSearchModeWithoutHelp(t *testing.T) {
 func TestFooterMinimalSearchViewModeIncludesViewModeCycleHint(t *testing.T) {
 	footer := Footer(FooterState{SearchMode: true, SearchQuery: "", ViewMode: settings.ViewModeSearch, ShowHelp: false})
 
-	assert.Contains(t, footer, "v: cycle view mode")
+	assert.Contains(t, footer, "Ctrl+v: cycle view mode")
 	assert.Contains(t, footer, "mode: [S]")
 }
 

--- a/internal/tui/state/model_coverage_regression_test.go
+++ b/internal/tui/state/model_coverage_regression_test.go
@@ -6,6 +6,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/cristianoliveira/tmux-intray/internal/notification"
 	"github.com/cristianoliveira/tmux-intray/internal/settings"
+	uimodel "github.com/cristianoliveira/tmux-intray/internal/tui/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -94,4 +95,20 @@ func TestSwitchActiveTabNoopWhenSameTab(t *testing.T) {
 
 	assert.Equal(t, settings.TabRecents, m.uiState.GetActiveTab())
 	assert.Equal(t, 1, m.uiState.GetCursor())
+}
+
+func TestSwitchToSessionsPreservesCurrentViewPreferences(t *testing.T) {
+	setupConfig(t, t.TempDir())
+
+	m := newTestModel(t, []notification.Notification{{ID: 1, Session: "$1", Message: "one"}})
+	m.uiState.SetViewMode(uimodel.ViewModeDetailed)
+	m.uiState.SetGroupBy(settings.GroupByWindow)
+	m.uiState.SetActiveTab(settings.TabAll)
+
+	m.switchActiveTab(settings.TabSessions)
+
+	assert.Equal(t, settings.TabSessions, m.uiState.GetActiveTab())
+	assert.Equal(t, settings.ViewModeDetailed, m.GetViewMode())
+	assert.Equal(t, settings.GroupByWindow, m.GetGroupBy())
+	assert.False(t, m.IsGroupedView())
 }

--- a/internal/tui/state/model_key_handlers.go
+++ b/internal/tui/state/model_key_handlers.go
@@ -5,7 +5,6 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/cristianoliveira/tmux-intray/internal/settings"
-	"github.com/cristianoliveira/tmux-intray/internal/tui/model"
 )
 
 // handleCtrlC handles Ctrl+C to exit the TUI.
@@ -81,12 +80,10 @@ func (m *Model) switchActiveTab(tab settings.Tab) {
 
 	m.uiState.SetActiveTab(nextTab)
 
-	// Sessions tab requires grouped view mode and all notifications to show session tree
+	// Sessions tab always renders as a session-grouped tree,
+	// but that is a tab-specific presentation and must not overwrite
+	// the user's persisted view mode or group-by preference.
 	if nextTab == settings.TabSessions {
-		if !m.isGroupedView() {
-			m.uiState.SetViewMode(model.ViewModeGrouped)
-			m.uiState.SetGroupBy(settings.GroupBySession)
-		}
 		if err := m.loadAllNotifications(); err != nil {
 			m.errorHandler.Warning(fmt.Sprintf("Failed to load notifications: %v", err))
 		}

--- a/internal/tui/state/model_keys_core.go
+++ b/internal/tui/state/model_keys_core.go
@@ -29,13 +29,6 @@ func (m *Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleConfirmation(msg)
 	}
 
-	// In search view mode we want `v` to keep cycling view modes.
-	// This is a special case because normal search mode treats runes as input.
-	if m.shouldCycleViewModeInSearchInput(msg) {
-		m.cycleViewMode()
-		return m, nil
-	}
-
 	if handled, cmd := m.handlePendingKey(msg); handled {
 		return m, cmd
 	}
@@ -137,6 +130,10 @@ func (m *Model) handleKeyType(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case tea.KeyCtrlS:
 		// Switch to Sessions tab in all views
 		return m.handleTabSwitchingKeys("s")
+	case tea.KeyCtrlV:
+		// Cycle view mode in all contexts.
+		m.cycleViewMode()
+		return m, nil
 	case tea.KeyCtrlH:
 		// In search contexts, Ctrl+h moves cursor left (same as normal navigation)
 		if m.isSearchContext() {
@@ -179,7 +176,7 @@ func (m *Model) handleKeyBinding(key string, allowInSearch bool) (tea.Model, tea
 		return m.handleTabSwitchingKeys(key)
 	case "R", "u":
 		return m.handleMarkKeys(key)
-	case "/", "?", "v":
+	case "/", "?":
 		return m.handleModeKeys(key, allowInSearch)
 	case "h", "l", "z":
 		return m.handleTreeKeys(key, allowInSearch)
@@ -242,7 +239,7 @@ func (m *Model) handleMarkKeys(key string) (tea.Model, tea.Cmd) {
 }
 
 // handleModeKeys handles mode and view key bindings.
-func (m *Model) handleModeKeys(key string, allowInSearch bool) (tea.Model, tea.Cmd) {
+func (m *Model) handleModeKeys(key string, _ bool) (tea.Model, tea.Cmd) {
 	switch key {
 	case "/":
 		m.handleSearchMode()
@@ -250,8 +247,6 @@ func (m *Model) handleModeKeys(key string, allowInSearch bool) (tea.Model, tea.C
 	case "?":
 		m.uiState.SetShowHelp(!m.uiState.ShowHelp())
 		return m, nil
-	case "v":
-		return m.handleBindingWithCheck(m.cycleViewMode, allowInSearch)
 	}
 	return m, nil
 }
@@ -334,16 +329,6 @@ func (m *Model) bindingKeyForMsg(msg tea.KeyMsg) (string, bool) {
 
 func (m *Model) isSearchContext() bool {
 	return m.currentKeyBindingContext() != keyBindingContextDefault
-}
-
-func (m *Model) shouldCycleViewModeInSearchInput(msg tea.KeyMsg) bool {
-	if m.currentKeyBindingContext() != keyBindingContextSearchInput {
-		return false
-	}
-	if m.uiState.GetViewMode() != model.ViewModeSearch {
-		return false
-	}
-	return msg.Type == tea.KeyRunes && msg.String() == "v"
 }
 
 func (m *Model) currentKeyBindingContext() keyBindingContext {

--- a/internal/tui/state/model_test.go
+++ b/internal/tui/state/model_test.go
@@ -1227,7 +1227,7 @@ func TestModelUpdateCyclesViewModesWithPersistence(t *testing.T) {
 	model.uiState.GetViewport().Width = 80
 	model.uiState.SetViewMode(settings.ViewModeDetailed)
 
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'v'}}
+	msg := tea.KeyMsg{Type: tea.KeyCtrlV}
 
 	updated, _ := model.Update(msg)
 	model = updated.(*Model)
@@ -1301,7 +1301,7 @@ func TestModelViewModeCycleThreeModeBehavior(t *testing.T) {
 			model.uiState.GetViewport().Width = 80
 			model.uiState.SetViewMode(tt.startMode)
 
-			msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'v'}}
+			msg := tea.KeyMsg{Type: tea.KeyCtrlV}
 
 			for i, expectedMode := range tt.expectedCycles {
 				updated, _ := model.Update(msg)
@@ -1320,11 +1320,11 @@ func TestModelUpdateIgnoresViewModeCycleInSearchMode(t *testing.T) {
 	model.uiState.GetViewport().Width = 80
 	model.uiState.SetViewMode(settings.ViewModeDetailed)
 
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'v'}}
+	msg := tea.KeyMsg{Type: tea.KeyCtrlV}
 	updated, _ := model.Update(msg)
 	model = updated.(*Model)
-	assert.Equal(t, settings.ViewModeDetailed, string(model.uiState.GetViewMode()))
-	assert.Equal(t, "v", model.uiState.GetSearchQuery())
+	assert.Equal(t, settings.ViewModeGrouped, string(model.uiState.GetViewMode()))
+	assert.Equal(t, "", model.uiState.GetSearchQuery())
 }
 
 func TestModelUpdateHandlesKeyBindingsInSearchMode(t *testing.T) {

--- a/plans/todo/split-concerns-cli-tui-shared-business-logic.md
+++ b/plans/todo/split-concerns-cli-tui-shared-business-logic.md
@@ -1,0 +1,92 @@
+# Split concerns: CLI/TUI adapters vs shared business logic
+
+## Goal
+Make `internal/app/*` the single source of truth for shared business behavior, while keeping:
+- `cmd/*` as the CLI adapter
+- `internal/tui/*` as the TUI adapter
+- `internal/domain/*` for domain rules
+- infra packages for implementation details
+
+## Problem
+The current risk is not that the project has two views.
+The risk is that the CLI may bypass or duplicate shared business logic that ideally belongs in `internal/app/*`.
+
+## Concerns split
+
+### 1. Inventory and classify current flows
+- [ ] Trace `add` flow across `cmd/tmux-intray/*`, `internal/app/*`, `internal/domain/*`, and storage/tmux/config packages
+- [ ] Trace `list` flow across the same layers
+- [ ] Trace `status` flow across the same layers
+- [ ] For each flow, classify code as one of:
+  - adapter/presentation
+  - application/use-case orchestration
+  - domain/business rule
+  - infrastructure/IO
+- [ ] Record duplication points where `cmd/*` reimplements behavior from `internal/app/*`
+
+### 2. Define target boundaries
+- [ ] Write a short boundary note for each layer:
+  - `cmd/*`: parse flags, invoke use cases, render CLI output, map errors to exit codes
+  - `internal/tui/*`: UI state, events, rendering, invoke use cases
+  - `internal/app/*`: shared use cases and orchestration
+  - `internal/domain/*`: pure business rules and entities
+  - infra packages: tmux, storage, config, hooks, filesystem, sqlite
+- [ ] Identify what data shape should cross each boundary
+- [ ] Decide which interfaces are canonical and which are duplicates to retire
+
+### 3. Move shared behavior into `internal/app/*`
+- [ ] Extract business decisions from `cmd/tmux-intray/add.go` into `internal/app/add.go`
+- [ ] Extract business decisions from `cmd/tmux-intray/list.go` into `internal/app/list.go`
+- [ ] Extract business decisions from `cmd/tmux-intray/status.go` into `internal/app/status.go`
+- [ ] Keep only CLI-specific concerns in `cmd/*`:
+  - Cobra wiring
+  - flags/args parsing
+  - formatting/output
+  - exit code mapping
+- [ ] Ensure TUI uses the same application-level behavior where appropriate
+
+### 4. Clean dependency injection and composition
+- [ ] Identify hidden dependency creation inside use-case/service code
+- [ ] Move default dependency construction to the composition root (`cmd/tmux-intray/deps.go` or equivalent)
+- [ ] Inject config/time/tmux/search dependencies instead of resolving them inside shared logic
+- [ ] Remove or reduce package-level globals/default clients where they cross into business flow
+
+### 5. Simplify overlapping abstractions
+- [ ] Compare `internal/domain`, `internal/ports`, and `internal/storage` interfaces for overlap
+- [ ] Choose one canonical repository contract per boundary
+- [ ] Remove shallow duplicate interfaces that do not add value
+- [ ] Keep output-oriented formats (like TSV/string formatting) at adapter edges, not inside shared logic
+
+### 6. Lock behavior with tests first
+- [ ] Add characterization tests for current `add` behavior before moving code
+- [ ] Add characterization tests for current `list` behavior before moving code
+- [ ] Add characterization tests for current `status` behavior before moving code
+- [ ] Add adapter-level tests proving CLI delegates to shared application logic
+- [ ] Add/adjust TUI tests only where integration with shared logic changes
+- [ ] Replace time-sensitive test behavior with injectable clocks/tickers where needed
+
+### 7. Refactor incrementally
+- [ ] Refactor one flow at a time, starting with `list` or `add`
+- [ ] After each flow move, remove dead/duplicated code immediately
+- [ ] Re-run targeted tests after each step
+- [ ] Run full validation once all three flows are aligned
+
+### 8. Documentation and follow-up
+- [ ] Update architecture docs to explicitly describe CLI/TUI as two adapters over shared use cases
+- [ ] Add a small diagram showing adapter → app → domain → infra relationships
+- [ ] Capture any leftover follow-up work as explicit tasks in `plans/todo/` or `bd`
+
+## Suggested execution order
+1. Characterize `list`
+2. Move `list` shared logic into `internal/app/list.go`
+3. Make CLI a thin adapter for `list`
+4. Repeat for `add`
+5. Repeat for `status`
+6. Simplify interfaces and DI after behavior is unified
+
+## Done when
+- `cmd/*` no longer contains shared business decisions for `add`, `list`, and `status`
+- `internal/app/*` is the canonical use-case layer for both CLI and TUI
+- domain rules live in `internal/domain/*`
+- infra details are injected, not created inside use cases
+- tests prove adapters delegate correctly and behavior remains stable


### PR DESCRIPTION
## Summary
This PR consolidates CLI command behavior around shared app use cases and includes TUI keyboard/view-mode improvements plus docs updates.

### What changed
- **Refactor (CLI → app use cases)**
  - `list` command now delegates to shared app use case
  - `add` command now delegates to shared app use case
  - `status` command now delegates to shared app use case
- **TUI behavior fixes/improvements**
  - Preserve current view when switching to **Sessions** tab
  - Change **cycle view mode** mapping to `Ctrl+v`
- **Documentation refresh**
  - Updated docs to reflect current behavior and shortcuts

## Why
- Reduce command-layer duplication
- Keep behavior consistent across CLI entry points
- Improve keyboard ergonomics and avoid conflicting key mappings
- Ensure docs match actual runtime behavior

## Verification
- `make lint`
- `make tests`

Both passed locally before push.

## Notes for reviewers
- Keybinding change touches:
  - key handling in TUI state
  - footer/help rendering text
  - shortcut docs
  - related tests
- Refactor is intended to be behavior-preserving except where explicitly noted above.
