### PR TITLE
test: align simple list output expectations

### DIFF
--- a/cmd/tmux-intray/list_recents_test.go
+++ b/cmd/tmux-intray/list_recents_test.go
@@ -20,12 +20,15 @@ func TestFormatRecentsUsingListFormatterSimpleMatchesListStyle(t *testing.T) {
 	formatRecentsUsingListFormatter(notifs, format.FormatterTypeSimple, &buf)
 
 	out := buf.String()
-	// list simple format starts with the numeric ID
+	// simple format starts with the numeric ID
 	if !strings.HasPrefix(out, "42") {
 		t.Fatalf("expected output to start with notification id, got: %q", out)
 	}
-	if !strings.Contains(out, "- boom") {
-		t.Fatalf("expected output to include message, got: %q", out)
+
+	// Output is column-based (same as internal/format SimpleFormatter)
+	cols := splitSimpleColumns(t, strings.TrimSpace(out))
+	if got := cols[6]; got != "boom" {
+		t.Fatalf("expected message column to be %q, got: %q (full=%q)", "boom", got, out)
 	}
 }
 

--- a/cmd/tmux-intray/list_tabs_test.go
+++ b/cmd/tmux-intray/list_tabs_test.go
@@ -22,8 +22,10 @@ func TestFormatTabsUsingListFormatterSimple(t *testing.T) {
 	if !strings.HasPrefix(out, "42") {
 		t.Fatalf("expected output to start with notification id, got: %q", out)
 	}
-	if !strings.Contains(out, "- Test message") {
-		t.Fatalf("expected output to include message, got: %q", out)
+
+	cols := splitSimpleColumns(t, strings.TrimSpace(out))
+	if got := cols[6]; got != "Test message" {
+		t.Fatalf("expected message column to be %q, got: %q (full=%q)", "Test message", got, out)
 	}
 }
 


### PR DESCRIPTION
Fix failing CLI tests by aligning simple-format expectations with internal/format SimpleFormatter (column-based output).