### PR TITLE
feat: hide stale tmux targets by default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,11 @@ This project follows minimalist, Unix‑style principles focused on quiet notifi
 
 Detailed development guidelines in [DEVELOPMENT.md](./DEVELOPMENT.md).
 
+### Code Placement Rules
+
+- `cmd/tmux-intray/` must stay pure entrypoints: command wiring, flags, validation, dependency injection, and calls into internal packages only.
+- Do not add business logic or helper modules under `cmd/tmux-intray/`; move reusable behavior to `internal/` and test it there.
+
 ### Essential Documentation
 
 - **Package Structure**: See [Go Package Structure](./docs/design/go-package-structure.md)

--- a/cmd/tmux-intray/display_name_filter.go
+++ b/cmd/tmux-intray/display_name_filter.go
@@ -6,8 +6,8 @@ import (
 	"github.com/cristianoliveira/tmux-intray/internal/format"
 )
 
-func keepOnlyResolvableTmuxRows(notifs []*domain.Notification, ftype format.FormatterType, displayNames appcore.DisplayNames, rawIDs bool) []*domain.Notification {
-	if rawIDs || ftype != format.FormatterTypeSimple {
+func keepOnlyResolvableTmuxRows(notifs []*domain.Notification, ftype format.FormatterType, displayNames appcore.DisplayNames, rawIDs, showStale bool) []*domain.Notification {
+	if showStale || rawIDs || ftype != format.FormatterTypeSimple {
 		return notifs
 	}
 
@@ -16,27 +16,9 @@ func keepOnlyResolvableTmuxRows(notifs []*domain.Notification, ftype format.Form
 		if notif == nil {
 			continue
 		}
-		if hasResolvedTmuxNames(*notif, displayNames) {
+		if displayNames.IsResolvedNotification(*notif) {
 			filtered = append(filtered, notif)
 		}
 	}
 	return filtered
-}
-
-func hasResolvedTmuxNames(notif domain.Notification, displayNames appcore.DisplayNames) bool {
-	if notif.Session == "" || notif.Window == "" || notif.Pane == "" {
-		return false
-	}
-
-	if displayNames.Sessions[notif.Session] == "" {
-		return false
-	}
-	if displayNames.Windows[notif.Window] == "" {
-		return false
-	}
-	if displayNames.Panes[notif.Pane] == "" {
-		return false
-	}
-
-	return true
 }

--- a/cmd/tmux-intray/list.go
+++ b/cmd/tmux-intray/list.go
@@ -35,6 +35,7 @@ OPTIONS:
     --session <id|name>  Filter notifications by session ID or session name
     --window <id|name>   Filter notifications by window ID or window name
     --ids                Show raw tmux session/window/pane IDs instead of resolved names
+    --show-stale         Include notifications whose tmux session/window/pane no longer exists
     --older-than <days>  Show notifications older than N days
     --newer-than <days>  Show notifications newer than N days
     --search <pattern>   Search messages (substring match)
@@ -90,6 +91,7 @@ func NewListCmd(client listClient, searchProviderFactory appcore.SearchProviderF
 	var listTab string
 	var listJSON bool
 	var listRawIDs bool
+	var listShowStale bool
 
 	listCmd.RunE = func(cmd *cobra.Command, args []string) error {
 		// Handle --json flag
@@ -128,6 +130,7 @@ func NewListCmd(client listClient, searchProviderFactory appcore.SearchProviderF
 				ReadFilter:   listFilter,
 				DisplayNames: displayNames,
 				RawIDs:       listRawIDs,
+				ShowStale:    listShowStale,
 			}
 			PrintTab(tabOpts)
 			return nil
@@ -157,6 +160,7 @@ func NewListCmd(client listClient, searchProviderFactory appcore.SearchProviderF
 			SearchProvider: buildListSearchProvider(listSearch, listRegex, displayNames),
 			DisplayNames:   displayNames,
 			RawIDs:         listRawIDs,
+			ShowStale:      listShowStale,
 		}
 		PrintListTo(opts, cmd.OutOrStdout(), searchProviderFactory)
 		return nil
@@ -170,6 +174,7 @@ func NewListCmd(client listClient, searchProviderFactory appcore.SearchProviderF
 	// Add --json flag
 	listCmd.Flags().BoolVar(&listJSON, "json", false, "Output in JSON format")
 	listCmd.Flags().BoolVar(&listRawIDs, "ids", false, "Show raw tmux session/window/pane IDs instead of resolved names")
+	listCmd.Flags().BoolVar(&listShowStale, "show-stale", false, "Include notifications whose tmux session/window/pane no longer exists")
 
 	return listCmd
 }

--- a/cmd/tmux-intray/list_recents.go
+++ b/cmd/tmux-intray/list_recents.go
@@ -27,6 +27,7 @@ type RecentsOptions struct {
 	ReadFilter   string
 	DisplayNames appcore.DisplayNames
 	RawIDs       bool
+	ShowStale    bool
 }
 
 // recentsOutputWriter is the writer used by PrintRecents. Can be changed for testing.
@@ -90,20 +91,20 @@ func printRecents(opts RecentsOptions, w io.Writer) {
 
 	switch opts.Format {
 	case "json":
-		formatRecentsUsingListFormatter(sessionBest, format.FormatterTypeJSON, opts.DisplayNames, opts.RawIDs, w)
+		formatRecentsUsingListFormatter(sessionBest, format.FormatterTypeJSON, opts.DisplayNames, opts.RawIDs, opts.ShowStale, w)
 	case "table":
-		formatRecentsUsingListFormatter(sessionBest, format.FormatterTypeTable, opts.DisplayNames, opts.RawIDs, w)
+		formatRecentsUsingListFormatter(sessionBest, format.FormatterTypeTable, opts.DisplayNames, opts.RawIDs, opts.ShowStale, w)
 	case "legacy":
-		formatRecentsUsingListFormatter(sessionBest, format.FormatterTypeLegacy, opts.DisplayNames, opts.RawIDs, w)
+		formatRecentsUsingListFormatter(sessionBest, format.FormatterTypeLegacy, opts.DisplayNames, opts.RawIDs, opts.ShowStale, w)
 	case "compact":
-		formatRecentsUsingListFormatter(sessionBest, format.FormatterTypeCompact, opts.DisplayNames, opts.RawIDs, w)
+		formatRecentsUsingListFormatter(sessionBest, format.FormatterTypeCompact, opts.DisplayNames, opts.RawIDs, opts.ShowStale, w)
 	default:
 		// Keep default aligned with `tmux-intray list` (simple formatter)
-		formatRecentsUsingListFormatter(sessionBest, format.FormatterTypeSimple, opts.DisplayNames, opts.RawIDs, w)
+		formatRecentsUsingListFormatter(sessionBest, format.FormatterTypeSimple, opts.DisplayNames, opts.RawIDs, opts.ShowStale, w)
 	}
 }
 
-func formatRecentsUsingListFormatter(notifs []notification.Notification, ftype format.FormatterType, displayNames appcore.DisplayNames, rawIDs bool, w io.Writer) {
+func formatRecentsUsingListFormatter(notifs []notification.Notification, ftype format.FormatterType, displayNames appcore.DisplayNames, rawIDs, showStale bool, w io.Writer) {
 	// Use the same formatter implementation as `tmux-intray list`.
 	formatter := format.NewFormatter(ftype)
 
@@ -125,7 +126,7 @@ func formatRecentsUsingListFormatter(notifs []notification.Notification, ftype f
 		})
 	}
 
-	domainNotifs = keepOnlyResolvableTmuxRows(domainNotifs, ftype, displayNames, rawIDs)
+	domainNotifs = keepOnlyResolvableTmuxRows(domainNotifs, ftype, displayNames, rawIDs, showStale)
 	if !rawIDs && ftype == format.FormatterTypeSimple {
 		domainNotifs = displayNames.EnrichNotifications(domainNotifs)
 	}
@@ -196,6 +197,7 @@ type TabOptions struct {
 	ReadFilter   string
 	DisplayNames appcore.DisplayNames
 	RawIDs       bool
+	ShowStale    bool
 }
 
 // PrintTab prints the specified tab view.
@@ -215,6 +217,7 @@ func PrintTab(opts TabOptions) {
 			ReadFilter:   opts.ReadFilter,
 			DisplayNames: opts.DisplayNames,
 			RawIDs:       opts.RawIDs,
+			ShowStale:    opts.ShowStale,
 		})
 	case "sessions":
 		PrintTabs(TabsOptions{
@@ -230,6 +233,7 @@ func PrintTab(opts TabOptions) {
 			ReadFilter:   opts.ReadFilter,
 			DisplayNames: opts.DisplayNames,
 			RawIDs:       opts.RawIDs,
+			ShowStale:    opts.ShowStale,
 		})
 	case "all":
 		PrintList(FilterOptions{
@@ -242,6 +246,7 @@ func PrintTab(opts TabOptions) {
 			Pane:         opts.Pane,
 			DisplayNames: opts.DisplayNames,
 			RawIDs:       opts.RawIDs,
+			ShowStale:    opts.ShowStale,
 		})
 	}
 }

--- a/cmd/tmux-intray/list_recents.go
+++ b/cmd/tmux-intray/list_recents.go
@@ -126,7 +126,7 @@ func formatRecentsUsingListFormatter(notifs []notification.Notification, ftype f
 		})
 	}
 
-	domainNotifs = keepOnlyResolvableTmuxRows(domainNotifs, ftype, displayNames, rawIDs, showStale)
+	domainNotifs = appcore.KeepOnlyResolvableTmuxRows(domainNotifs, ftype, displayNames, rawIDs, showStale)
 	if !rawIDs && ftype == format.FormatterTypeSimple {
 		domainNotifs = displayNames.EnrichNotifications(domainNotifs)
 	}

--- a/cmd/tmux-intray/list_recents_test.go
+++ b/cmd/tmux-intray/list_recents_test.go
@@ -18,7 +18,7 @@ func TestFormatRecentsUsingListFormatterSimpleMatchesListStyle(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	formatRecentsUsingListFormatter(notifs, format.FormatterTypeSimple, appcore.DisplayNames{}, true, &buf)
+	formatRecentsUsingListFormatter(notifs, format.FormatterTypeSimple, appcore.DisplayNames{}, true, false, &buf)
 
 	out := buf.String()
 	// simple format starts with the numeric ID
@@ -41,7 +41,7 @@ func TestFormatRecentsUsingListFormatterSimpleUsesResolvedNamesByDefault(t *test
 		Sessions: map[string]string{"$1": "work"},
 		Windows:  map[string]string{"@2": "editor"},
 		Panes:    map[string]string{"%3": "shell"},
-	}, false, &buf)
+	}, false, false, &buf)
 
 	cols := splitSimpleColumns(t, strings.TrimSpace(buf.String()))
 	if cols[2] != "work" || cols[3] != "editor" || cols[4] != "shell" {
@@ -55,8 +55,9 @@ func TestFormatRecentsUsingListFormatterSimpleOmitsRowsWhenNamesCannotBeResolved
 	var buf bytes.Buffer
 	formatRecentsUsingListFormatter(notifs, format.FormatterTypeSimple, appcore.DisplayNames{
 		Sessions: map[string]string{"$1": "work"},
-		// window and pane names missing
-	}, false, &buf)
+		Windows:  map[string]string{},
+		Panes:    map[string]string{},
+	}, false, false, &buf)
 
 	if strings.TrimSpace(buf.String()) != "" {
 		t.Fatalf("expected unresolved row to be omitted, got: %q", buf.String())
@@ -69,7 +70,7 @@ func TestFormatRecentsUsingListFormatterSimpleKeepsRowsWithRawIDsFlag(t *testing
 	var buf bytes.Buffer
 	formatRecentsUsingListFormatter(notifs, format.FormatterTypeSimple, appcore.DisplayNames{
 		Sessions: map[string]string{"$1": "work"},
-	}, true, &buf)
+	}, true, false, &buf)
 
 	cols := splitSimpleColumns(t, strings.TrimSpace(buf.String()))
 	if cols[2] != "$1" || cols[3] != "@2" || cols[4] != "%3" {
@@ -83,7 +84,7 @@ func TestFormatRecentsUsingListFormatterJSONIncludesID(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	formatRecentsUsingListFormatter(notifs, format.FormatterTypeJSON, appcore.DisplayNames{}, false, &buf)
+	formatRecentsUsingListFormatter(notifs, format.FormatterTypeJSON, appcore.DisplayNames{}, false, false, &buf)
 
 	var got []map[string]any
 	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {

--- a/cmd/tmux-intray/list_tabs.go
+++ b/cmd/tmux-intray/list_tabs.go
@@ -98,7 +98,7 @@ func formatTabsUsingListFormatter(groups []domain.SessionNotification, ftype for
 		n := groups[i].Notification
 		notifs = append(notifs, &n)
 	}
-	notifs = keepOnlyResolvableTmuxRows(notifs, ftype, displayNames, rawIDs, showStale)
+	notifs = appcore.KeepOnlyResolvableTmuxRows(notifs, ftype, displayNames, rawIDs, showStale)
 	if !rawIDs && ftype == format.FormatterTypeSimple {
 		notifs = displayNames.EnrichNotifications(notifs)
 	}

--- a/cmd/tmux-intray/list_tabs.go
+++ b/cmd/tmux-intray/list_tabs.go
@@ -26,6 +26,7 @@ type TabsOptions struct {
 	ReadFilter   string
 	DisplayNames appcore.DisplayNames
 	RawIDs       bool
+	ShowStale    bool
 }
 
 // tabsOutputWriter is the writer used by PrintTabs. Can be changed for testing.
@@ -77,19 +78,19 @@ func printTabs(opts TabsOptions, w io.Writer) {
 	// Render using the same formatter implementation as `tmux-intray list`.
 	switch opts.Format {
 	case "json":
-		formatTabsUsingListFormatter(sessionGroups, format.FormatterTypeJSON, opts.DisplayNames, opts.RawIDs, w)
+		formatTabsUsingListFormatter(sessionGroups, format.FormatterTypeJSON, opts.DisplayNames, opts.RawIDs, opts.ShowStale, w)
 	case "table":
-		formatTabsUsingListFormatter(sessionGroups, format.FormatterTypeTable, opts.DisplayNames, opts.RawIDs, w)
+		formatTabsUsingListFormatter(sessionGroups, format.FormatterTypeTable, opts.DisplayNames, opts.RawIDs, opts.ShowStale, w)
 	case "legacy":
-		formatTabsUsingListFormatter(sessionGroups, format.FormatterTypeLegacy, opts.DisplayNames, opts.RawIDs, w)
+		formatTabsUsingListFormatter(sessionGroups, format.FormatterTypeLegacy, opts.DisplayNames, opts.RawIDs, opts.ShowStale, w)
 	case "compact":
-		formatTabsUsingListFormatter(sessionGroups, format.FormatterTypeCompact, opts.DisplayNames, opts.RawIDs, w)
+		formatTabsUsingListFormatter(sessionGroups, format.FormatterTypeCompact, opts.DisplayNames, opts.RawIDs, opts.ShowStale, w)
 	default:
-		formatTabsUsingListFormatter(sessionGroups, format.FormatterTypeSimple, opts.DisplayNames, opts.RawIDs, w)
+		formatTabsUsingListFormatter(sessionGroups, format.FormatterTypeSimple, opts.DisplayNames, opts.RawIDs, opts.ShowStale, w)
 	}
 }
 
-func formatTabsUsingListFormatter(groups []domain.SessionNotification, ftype format.FormatterType, displayNames appcore.DisplayNames, rawIDs bool, w io.Writer) {
+func formatTabsUsingListFormatter(groups []domain.SessionNotification, ftype format.FormatterType, displayNames appcore.DisplayNames, rawIDs, showStale bool, w io.Writer) {
 	formatter := format.NewFormatter(ftype)
 
 	notifs := make([]*domain.Notification, 0, len(groups))
@@ -97,7 +98,7 @@ func formatTabsUsingListFormatter(groups []domain.SessionNotification, ftype for
 		n := groups[i].Notification
 		notifs = append(notifs, &n)
 	}
-	notifs = keepOnlyResolvableTmuxRows(notifs, ftype, displayNames, rawIDs)
+	notifs = keepOnlyResolvableTmuxRows(notifs, ftype, displayNames, rawIDs, showStale)
 	if !rawIDs && ftype == format.FormatterTypeSimple {
 		notifs = displayNames.EnrichNotifications(notifs)
 	}

--- a/cmd/tmux-intray/list_tabs_json_test.go
+++ b/cmd/tmux-intray/list_tabs_json_test.go
@@ -16,7 +16,7 @@ func TestFormatTabsUsingListFormatterJSONIncludesIDField(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	formatTabsUsingListFormatter(groups, format.FormatterTypeJSON, appcore.DisplayNames{}, false, &buf)
+	formatTabsUsingListFormatter(groups, format.FormatterTypeJSON, appcore.DisplayNames{}, false, false, &buf)
 
 	var got []map[string]any
 	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {

--- a/cmd/tmux-intray/list_tabs_test.go
+++ b/cmd/tmux-intray/list_tabs_test.go
@@ -17,7 +17,7 @@ func TestFormatTabsUsingListFormatterSimple(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	formatTabsUsingListFormatter(groups, format.FormatterTypeSimple, appcore.DisplayNames{}, true, &buf)
+	formatTabsUsingListFormatter(groups, format.FormatterTypeSimple, appcore.DisplayNames{}, true, false, &buf)
 
 	out := buf.String()
 	if !strings.HasPrefix(out, "42") {
@@ -36,7 +36,7 @@ func TestFormatTabsUsingListFormatterTable(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	formatTabsUsingListFormatter(groups, format.FormatterTypeTable, appcore.DisplayNames{}, false, &buf)
+	formatTabsUsingListFormatter(groups, format.FormatterTypeTable, appcore.DisplayNames{}, false, false, &buf)
 
 	out := buf.String()
 	for _, want := range []string{"ID", "DATE", "7", "Test message"} {
@@ -48,7 +48,7 @@ func TestFormatTabsUsingListFormatterTable(t *testing.T) {
 
 func TestFormatTabsUsingListFormatterEmpty(t *testing.T) {
 	var buf bytes.Buffer
-	formatTabsUsingListFormatter(nil, format.FormatterTypeSimple, appcore.DisplayNames{}, false, &buf)
+	formatTabsUsingListFormatter(nil, format.FormatterTypeSimple, appcore.DisplayNames{}, false, false, &buf)
 	if buf.Len() != 0 {
 		t.Fatalf("expected no output for empty groups, got: %q", buf.String())
 	}
@@ -62,7 +62,7 @@ func TestFormatTabsUsingListFormatterSimpleUsesResolvedNamesByDefault(t *testing
 		Sessions: map[string]string{"$1": "work"},
 		Windows:  map[string]string{"@2": "editor"},
 		Panes:    map[string]string{"%3": "shell"},
-	}, false, &buf)
+	}, false, false, &buf)
 
 	cols := splitSimpleColumns(t, strings.TrimSpace(buf.String()))
 	if cols[2] != "work" || cols[3] != "editor" || cols[4] != "shell" {
@@ -76,8 +76,9 @@ func TestFormatTabsUsingListFormatterSimpleOmitsRowsWhenNamesCannotBeResolved(t 
 	var buf bytes.Buffer
 	formatTabsUsingListFormatter(groups, format.FormatterTypeSimple, appcore.DisplayNames{
 		Sessions: map[string]string{"$1": "work"},
-		// window and pane names missing
-	}, false, &buf)
+		Windows:  map[string]string{},
+		Panes:    map[string]string{},
+	}, false, false, &buf)
 
 	if strings.TrimSpace(buf.String()) != "" {
 		t.Fatalf("expected unresolved row to be omitted, got %q", buf.String())
@@ -92,7 +93,7 @@ func TestFormatTabsUsingListFormatterSimpleKeepsRawIDsWithExplicitFlag(t *testin
 		Sessions: map[string]string{"$1": "work"},
 		Windows:  map[string]string{"@2": "editor"},
 		Panes:    map[string]string{"%3": "shell"},
-	}, true, &buf)
+	}, true, false, &buf)
 
 	cols := splitSimpleColumns(t, strings.TrimSpace(buf.String()))
 	if cols[2] != "$1" || cols[3] != "@2" || cols[4] != "%3" {

--- a/cmd/tmux-intray/list_test.go
+++ b/cmd/tmux-intray/list_test.go
@@ -595,7 +595,7 @@ func TestPrintListSimpleFormatUsesResolvedNamesByDefault(t *testing.T) {
 	assert.Equal(t, "shell", cols[4])
 }
 
-func TestPrintListSimpleFormatFallsBackToRawIDsWhenNamesUnavailable(t *testing.T) {
+func TestPrintListSimpleFormatUsesReadableFallbackWhenNamesUnavailable(t *testing.T) {
 	output := runPrintList(t,
 		"1\t2025-01-01T10:00:00Z\tactive\t$1\t@2\t%3\tmessage one\t123\tinfo\t\n",
 		nil,
@@ -609,8 +609,8 @@ func TestPrintListSimpleFormatFallsBackToRawIDsWhenNamesUnavailable(t *testing.T
 
 	cols := splitSimpleColumns(t, strings.TrimSpace(output))
 	assert.Equal(t, "work", cols[2])
-	assert.Equal(t, "@2", cols[3])
-	assert.Equal(t, "%3", cols[4])
+	assert.Equal(t, "stale-window:@2", cols[3])
+	assert.Equal(t, "stale-pane:%3", cols[4])
 }
 
 func TestPrintListGroupCountUsesResolvedGroupNamesByDefault(t *testing.T) {

--- a/cmd/tmux-intray/tui.go
+++ b/cmd/tmux-intray/tui.go
@@ -26,7 +26,9 @@ func NewTUICmd(client tuiClient) *cobra.Command {
 		panic("NewTUICmd: client dependency cannot be nil")
 	}
 
-	return &cobra.Command{
+	var showStale bool
+
+	cmd := &cobra.Command{
 		Use:   "tui",
 		Short: "Interactive terminal UI for notifications",
 		Long: `Interactive terminal UI for notifications.
@@ -46,6 +48,9 @@ KEY BINDINGS:
     u           Mark selected notification as unread
     Enter       Jump to pane/window target
     q           Quit TUI
+
+OPTIONS:
+    --show-stale Include notifications whose tmux session/window/pane no longer exists
 
 NOTES:
     - Settings are saved automatically on quit.
@@ -69,6 +74,7 @@ NOTES:
 
 			// Store loaded settings reference
 			model.SetLoadedSettings(loadedSettings)
+			model.SetShowStale(showStale)
 
 			// Apply loaded settings to model
 			st := settings.FromSettings(loadedSettings)
@@ -95,4 +101,7 @@ NOTES:
 			return client.RunProgram(model)
 		},
 	}
+
+	cmd.Flags().BoolVar(&showStale, "show-stale", false, "Include notifications whose tmux session/window/pane no longer exists")
+	return cmd
 }

--- a/internal/app/display_names.go
+++ b/internal/app/display_names.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"strings"
+
 	"github.com/cristianoliveira/tmux-intray/internal/domain"
 )
 
@@ -11,7 +13,7 @@ type DisplayNames struct {
 	Panes    map[string]string
 }
 
-// Resolve returns a display value for the given kind, falling back to the raw tmux ID.
+// Resolve returns a display value for the given kind, falling back to a readable missing label.
 func (d DisplayNames) Resolve(kind, raw string) string {
 	if raw == "" {
 		return raw
@@ -29,13 +31,47 @@ func (d DisplayNames) Resolve(kind, raw string) string {
 		return raw
 	}
 
-	if names == nil {
-		return raw
-	}
 	if resolved := names[raw]; resolved != "" {
 		return resolved
 	}
+	return MissingDisplayName(kind, raw)
+}
+
+// MissingDisplayName returns a human-readable fallback for stale tmux IDs.
+func MissingDisplayName(kind, raw string) string {
+	if raw == "" {
+		return raw
+	}
+
+	switch kind {
+	case "session":
+		if strings.HasPrefix(raw, "$") {
+			return "stale-session:" + raw
+		}
+	case "window":
+		if strings.HasPrefix(raw, "@") {
+			return "stale-window:" + raw
+		}
+	case "pane":
+		if strings.HasPrefix(raw, "%") {
+			return "stale-pane:" + raw
+		}
+	}
 	return raw
+}
+
+// IsResolvedNotification reports whether all tmux routing IDs have live display names.
+func (d DisplayNames) IsResolvedNotification(notif domain.Notification) bool {
+	if d.Sessions != nil && d.Sessions[notif.Session] == "" {
+		return false
+	}
+	if d.Windows != nil && d.Windows[notif.Window] == "" {
+		return false
+	}
+	if d.Panes != nil && d.Panes[notif.Pane] == "" {
+		return false
+	}
+	return true
 }
 
 // EnrichNotification returns a copy with human-readable tmux labels.

--- a/internal/app/display_names.go
+++ b/internal/app/display_names.go
@@ -62,13 +62,13 @@ func MissingDisplayName(kind, raw string) string {
 
 // IsResolvedNotification reports whether all tmux routing IDs have live display names.
 func (d DisplayNames) IsResolvedNotification(notif domain.Notification) bool {
-	if d.Sessions != nil && d.Sessions[notif.Session] == "" {
+	if notif.Session != "" && d.Sessions != nil && d.Sessions[notif.Session] == "" {
 		return false
 	}
-	if d.Windows != nil && d.Windows[notif.Window] == "" {
+	if notif.Window != "" && d.Windows != nil && d.Windows[notif.Window] == "" {
 		return false
 	}
-	if d.Panes != nil && d.Panes[notif.Pane] == "" {
+	if notif.Pane != "" && d.Panes != nil && d.Panes[notif.Pane] == "" {
 		return false
 	}
 	return true

--- a/internal/app/list.go
+++ b/internal/app/list.go
@@ -38,6 +38,7 @@ type ListOptions struct {
 	ReadFilter     string
 	DisplayNames   DisplayNames
 	RawIDs         bool
+	ShowStale      bool
 }
 
 // SearchProviderFactory builds a search provider for list behavior.
@@ -72,6 +73,12 @@ func (u *ListUseCase) Execute(opts ListOptions, w io.Writer) {
 
 	searchProvider := u.getSearchProvider(opts)
 	notifications := parseAndFilterNotifications(lines, searchProvider, opts.Search)
+	if len(notifications) == 0 {
+		_, _ = fmt.Fprintf(w, "%s%s%s\n", colors.Blue, "No notifications found", colors.Reset)
+		return
+	}
+
+	notifications = filterStaleNotifications(notifications, opts)
 	if len(notifications) == 0 {
 		_, _ = fmt.Fprintf(w, "%s%s%s\n", colors.Blue, "No notifications found", colors.Reset)
 		return
@@ -121,6 +128,23 @@ func parseAndFilterNotifications(lines string, searchProvider search.Provider, s
 		notifications = append(notifications, notification.ToDomainUnsafe(notif))
 	}
 	return notifications
+}
+
+func filterStaleNotifications(notifs []*domain.Notification, opts ListOptions) []*domain.Notification {
+	if opts.ShowStale || opts.RawIDs || opts.Format == "json" {
+		return notifs
+	}
+
+	filtered := make([]*domain.Notification, 0, len(notifs))
+	for _, notif := range notifs {
+		if notif == nil {
+			continue
+		}
+		if opts.DisplayNames.IsResolvedNotification(*notif) {
+			filtered = append(filtered, notif)
+		}
+	}
+	return filtered
 }
 
 func notificationsToValues(notifs []*domain.Notification) []domain.Notification {

--- a/internal/app/list.go
+++ b/internal/app/list.go
@@ -131,20 +131,7 @@ func parseAndFilterNotifications(lines string, searchProvider search.Provider, s
 }
 
 func filterStaleNotifications(notifs []*domain.Notification, opts ListOptions) []*domain.Notification {
-	if opts.ShowStale || opts.RawIDs || opts.Format == "json" {
-		return notifs
-	}
-
-	filtered := make([]*domain.Notification, 0, len(notifs))
-	for _, notif := range notifs {
-		if notif == nil {
-			continue
-		}
-		if opts.DisplayNames.IsResolvedNotification(*notif) {
-			filtered = append(filtered, notif)
-		}
-	}
-	return filtered
+	return KeepOnlyResolvableTmuxRows(notifs, format.FormatterType(opts.Format), opts.DisplayNames, opts.RawIDs, opts.ShowStale)
 }
 
 func notificationsToValues(notifs []*domain.Notification) []domain.Notification {

--- a/internal/app/list_test.go
+++ b/internal/app/list_test.go
@@ -178,6 +178,48 @@ func TestListUseCaseExecuteBuildsSearchProviderFromInjectedFactory(t *testing.T)
 	assert.NotContains(t, buf.String(), "warning message")
 }
 
+func TestListUseCaseHidesStaleTmuxRowsByDefault(t *testing.T) {
+	client := &fakeListClient{result: "1\t2025-01-01T10:00:00Z\tactive\t$1\t@1\t%1\tlive target\t123\tinfo\t\n" +
+		"2\t2025-01-01T10:01:00Z\tactive\t$180\t@329\t%703\tstale target\t124\tinfo\t\n"}
+	useCase := NewListUseCase(client, nil)
+
+	var buf bytes.Buffer
+	useCase.Execute(ListOptions{Format: "simple", DisplayNames: DisplayNames{
+		Sessions: map[string]string{"$1": "work"},
+		Windows:  map[string]string{"@1": "editor"},
+		Panes:    map[string]string{"%1": "shell"},
+	}}, &buf)
+
+	output := buf.String()
+	assert.Contains(t, output, "live target")
+	assert.NotContains(t, output, "stale target")
+	assert.NotContains(t, output, "stale-session:$180")
+}
+
+func TestListUseCaseShowsStaleTmuxRowsWhenRequested(t *testing.T) {
+	client := &fakeListClient{result: "1\t2025-01-01T10:00:00Z\tactive\t$180\t@329\t%703\tstale target\t123\tinfo\t\n"}
+	useCase := NewListUseCase(client, nil)
+
+	var buf bytes.Buffer
+	useCase.Execute(ListOptions{Format: "simple", DisplayNames: DisplayNames{}, ShowStale: true}, &buf)
+
+	output := buf.String()
+	assert.Contains(t, output, "stale-session:$180")
+	assert.Contains(t, output, "stale-window:@329")
+	assert.Contains(t, output, "stale-pane:%703")
+	assert.NotContains(t, output, "\t$180\t@329\t%703\t")
+}
+
+func TestListUseCaseGroupedOutputUsesReadableFallbackForStaleTmuxIDs(t *testing.T) {
+	client := &fakeListClient{result: "1\t2025-01-01T10:00:00Z\tactive\t$180\t@329\t%703\tstale target\t123\tinfo\t\n"}
+	useCase := NewListUseCase(client, nil)
+
+	var buf bytes.Buffer
+	useCase.Execute(ListOptions{Format: "simple", GroupBy: "session", GroupCount: true, DisplayNames: DisplayNames{}, ShowStale: true}, &buf)
+
+	assert.Contains(t, buf.String(), "Group: stale-session:$180 (1)")
+}
+
 func TestListUseCaseGroupedOutputKeepsRawSessionIdentityWhenDisplayNamesCollide(t *testing.T) {
 	client := &fakeListClient{result: "1\t2025-01-01T10:00:00Z\tactive\t$1\t@1\t%1\tmessage one\t123\tinfo\t\n" +
 		"2\t2025-01-01T11:00:00Z\tactive\t$2\t@2\t%2\tmessage two\t124\twarning\t\n"}
@@ -191,6 +233,7 @@ func TestListUseCaseGroupedOutputKeepsRawSessionIdentityWhenDisplayNamesCollide(
 		DisplayNames: DisplayNames{
 			Sessions: map[string]string{"$1": "work", "$2": "work"},
 		},
+		ShowStale: true,
 	}, &buf)
 
 	output := buf.String()
@@ -211,6 +254,7 @@ func TestListUseCaseGroupedOutputKeepsRawWindowIdentityWhenDisplayNamesCollide(t
 		DisplayNames: DisplayNames{
 			Windows: map[string]string{"@1": "editor", "@2": "editor"},
 		},
+		ShowStale: true,
 	}, &buf)
 
 	output := buf.String()

--- a/internal/app/stale_filter.go
+++ b/internal/app/stale_filter.go
@@ -1,12 +1,12 @@
-package main
+package app
 
 import (
-	appcore "github.com/cristianoliveira/tmux-intray/internal/app"
 	"github.com/cristianoliveira/tmux-intray/internal/domain"
 	"github.com/cristianoliveira/tmux-intray/internal/format"
 )
 
-func keepOnlyResolvableTmuxRows(notifs []*domain.Notification, ftype format.FormatterType, displayNames appcore.DisplayNames, rawIDs, showStale bool) []*domain.Notification {
+// KeepOnlyResolvableTmuxRows removes stale tmux rows from standard human-readable output.
+func KeepOnlyResolvableTmuxRows(notifs []*domain.Notification, ftype format.FormatterType, displayNames DisplayNames, rawIDs, showStale bool) []*domain.Notification {
 	if showStale || rawIDs || ftype != format.FormatterTypeSimple {
 		return notifs
 	}

--- a/internal/app/stale_filter.go
+++ b/internal/app/stale_filter.go
@@ -3,12 +3,25 @@ package app
 import (
 	"github.com/cristianoliveira/tmux-intray/internal/domain"
 	"github.com/cristianoliveira/tmux-intray/internal/format"
-	"github.com/cristianoliveira/tmux-intray/internal/notification"
 )
+
+// StaleFilterOptions controls whether stale tmux targets should be visible.
+type StaleFilterOptions struct {
+	DisplayNames DisplayNames
+	ShowStale    bool
+}
+
+// ShouldShowNotification is the canonical stale-target visibility decision.
+func ShouldShowNotification(notif domain.Notification, opts StaleFilterOptions) bool {
+	if opts.ShowStale {
+		return true
+	}
+	return opts.DisplayNames.IsResolvedNotification(notif)
+}
 
 // KeepOnlyResolvableTmuxRows removes stale tmux rows from standard human-readable output.
 func KeepOnlyResolvableTmuxRows(notifs []*domain.Notification, ftype format.FormatterType, displayNames DisplayNames, rawIDs, showStale bool) []*domain.Notification {
-	if showStale || rawIDs || ftype != format.FormatterTypeSimple {
+	if rawIDs || ftype != format.FormatterTypeSimple {
 		return notifs
 	}
 
@@ -17,23 +30,18 @@ func KeepOnlyResolvableTmuxRows(notifs []*domain.Notification, ftype format.Form
 		if notif == nil {
 			continue
 		}
-		if displayNames.IsResolvedNotification(*notif) {
+		if ShouldShowNotification(*notif, StaleFilterOptions{DisplayNames: displayNames, ShowStale: showStale}) {
 			filtered = append(filtered, notif)
 		}
 	}
 	return filtered
 }
 
-// KeepOnlyResolvableNotifications removes stale tmux notifications unless explicitly requested.
-func KeepOnlyResolvableNotifications(notifs []notification.Notification, displayNames DisplayNames, showStale bool) []notification.Notification {
-	if showStale {
-		return notifs
-	}
-
-	filtered := make([]notification.Notification, 0, len(notifs))
+// KeepOnlyResolvableNotifications removes stale tmux domain notifications unless explicitly requested.
+func KeepOnlyResolvableNotifications(notifs []domain.Notification, displayNames DisplayNames, showStale bool) []domain.Notification {
+	filtered := make([]domain.Notification, 0, len(notifs))
 	for _, notif := range notifs {
-		domainNotif := notification.ToDomainUnsafe(notif)
-		if domainNotif != nil && displayNames.IsResolvedNotification(*domainNotif) {
+		if ShouldShowNotification(notif, StaleFilterOptions{DisplayNames: displayNames, ShowStale: showStale}) {
 			filtered = append(filtered, notif)
 		}
 	}

--- a/internal/app/stale_filter.go
+++ b/internal/app/stale_filter.go
@@ -3,6 +3,7 @@ package app
 import (
 	"github.com/cristianoliveira/tmux-intray/internal/domain"
 	"github.com/cristianoliveira/tmux-intray/internal/format"
+	"github.com/cristianoliveira/tmux-intray/internal/notification"
 )
 
 // KeepOnlyResolvableTmuxRows removes stale tmux rows from standard human-readable output.
@@ -17,6 +18,22 @@ func KeepOnlyResolvableTmuxRows(notifs []*domain.Notification, ftype format.Form
 			continue
 		}
 		if displayNames.IsResolvedNotification(*notif) {
+			filtered = append(filtered, notif)
+		}
+	}
+	return filtered
+}
+
+// KeepOnlyResolvableNotifications removes stale tmux notifications unless explicitly requested.
+func KeepOnlyResolvableNotifications(notifs []notification.Notification, displayNames DisplayNames, showStale bool) []notification.Notification {
+	if showStale {
+		return notifs
+	}
+
+	filtered := make([]notification.Notification, 0, len(notifs))
+	for _, notif := range notifs {
+		domainNotif := notification.ToDomainUnsafe(notif)
+		if domainNotif != nil && displayNames.IsResolvedNotification(*domainNotif) {
 			filtered = append(filtered, notif)
 		}
 	}

--- a/internal/tui/app/client.go
+++ b/internal/tui/app/client.go
@@ -15,6 +15,7 @@ import (
 type Model interface {
 	tea.Model
 	SetLoadedSettings(loadedSettings *settings.Settings)
+	SetShowStale(show bool)
 	FromState(settingsState settings.TUIState) error
 }
 

--- a/internal/tui/app/client_test.go
+++ b/internal/tui/app/client_test.go
@@ -113,6 +113,7 @@ func (m *mockModel) View() string {
 }
 
 func (m *mockModel) SetLoadedSettings(loadedSettings *settings.Settings) {}
+func (m *mockModel) SetShowStale(show bool)                              {}
 
 func (m *mockModel) FromState(settingsState settings.TUIState) error {
 	return nil

--- a/internal/tui/model/notification_service.go
+++ b/internal/tui/model/notification_service.go
@@ -13,6 +13,9 @@ type NotificationService interface {
 	// SetNotifications updates the underlying notification dataset.
 	SetNotifications(notifications []notification.Notification)
 
+	// SetShowStale controls whether notifications for stale tmux targets remain visible.
+	SetShowStale(show bool)
+
 	// GetNotifications returns all notifications currently tracked by the service.
 	GetNotifications() []notification.Notification
 

--- a/internal/tui/service/notification_service.go
+++ b/internal/tui/service/notification_service.go
@@ -20,6 +20,7 @@ type DefaultNotificationService struct {
 	settings       *settings.Settings
 	notifications  []notification.Notification
 	filtered       []notification.Notification
+	showStale      bool
 }
 
 const (
@@ -51,6 +52,11 @@ func NewNotificationService(provider search.Provider, resolver model.NameResolve
 		notifications:  []notification.Notification{},
 		filtered:       []notification.Notification{},
 	}
+}
+
+// SetShowStale controls whether notifications for stale tmux targets remain visible.
+func (s *DefaultNotificationService) SetShowStale(show bool) {
+	s.showStale = show
 }
 
 // SetSettings updates the settings used by the service.
@@ -341,6 +347,31 @@ func (s *DefaultNotificationService) selectDataset(activeTab settings.Tab, sortB
 	return activeOnly
 }
 
+// FilterResolvableTmuxTargets hides notifications whose tmux session/window/pane no longer exists.
+func (s *DefaultNotificationService) FilterResolvableTmuxTargets(notifications []notification.Notification) []notification.Notification {
+	if s.nameResolver == nil {
+		return notifications
+	}
+
+	sessions := s.nameResolver.GetSessionNames()
+	windows := s.nameResolver.GetWindowNames()
+	panes := s.nameResolver.GetPaneNames()
+	filtered := make([]notification.Notification, 0, len(notifications))
+	for _, n := range notifications {
+		if len(sessions) > 0 && sessions[n.Session] == "" {
+			continue
+		}
+		if len(windows) > 0 && windows[n.Window] == "" {
+			continue
+		}
+		if len(panes) > 0 && panes[n.Pane] == "" {
+			continue
+		}
+		filtered = append(filtered, n)
+	}
+	return filtered
+}
+
 // ApplyFiltersAndSearch applies tab scope, then filters/search/sorting and stores filtered results.
 func (s *DefaultNotificationService) ApplyFiltersAndSearch(tab settings.Tab, query, state, level, sessionID, windowID, paneID, readFilter, sortBy, sortOrder string) {
 	if settings.NormalizeTab(string(tab)) == settings.TabRecents {
@@ -348,6 +379,9 @@ func (s *DefaultNotificationService) ApplyFiltersAndSearch(tab settings.Tab, que
 	}
 
 	result := s.selectDataset(tab, sortBy, sortOrder)
+	if !s.showStale {
+		result = s.FilterResolvableTmuxTargets(result)
+	}
 
 	// Check if this is a filtered view (drilling down into a specific session/window/pane)
 	isFilteredView := sessionID != "" || windowID != "" || paneID != ""

--- a/internal/tui/service/notification_service.go
+++ b/internal/tui/service/notification_service.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	appcore "github.com/cristianoliveira/tmux-intray/internal/app"
 	"github.com/cristianoliveira/tmux-intray/internal/config"
 	"github.com/cristianoliveira/tmux-intray/internal/domain"
 	"github.com/cristianoliveira/tmux-intray/internal/notification"
@@ -353,23 +354,11 @@ func (s *DefaultNotificationService) FilterResolvableTmuxTargets(notifications [
 		return notifications
 	}
 
-	sessions := s.nameResolver.GetSessionNames()
-	windows := s.nameResolver.GetWindowNames()
-	panes := s.nameResolver.GetPaneNames()
-	filtered := make([]notification.Notification, 0, len(notifications))
-	for _, n := range notifications {
-		if len(sessions) > 0 && sessions[n.Session] == "" {
-			continue
-		}
-		if len(windows) > 0 && windows[n.Window] == "" {
-			continue
-		}
-		if len(panes) > 0 && panes[n.Pane] == "" {
-			continue
-		}
-		filtered = append(filtered, n)
-	}
-	return filtered
+	return appcore.KeepOnlyResolvableNotifications(notifications, appcore.DisplayNames{
+		Sessions: s.nameResolver.GetSessionNames(),
+		Windows:  s.nameResolver.GetWindowNames(),
+		Panes:    s.nameResolver.GetPaneNames(),
+	}, s.showStale)
 }
 
 // ApplyFiltersAndSearch applies tab scope, then filters/search/sorting and stores filtered results.
@@ -379,9 +368,7 @@ func (s *DefaultNotificationService) ApplyFiltersAndSearch(tab settings.Tab, que
 	}
 
 	result := s.selectDataset(tab, sortBy, sortOrder)
-	if !s.showStale {
-		result = s.FilterResolvableTmuxTargets(result)
-	}
+	result = s.FilterResolvableTmuxTargets(result)
 
 	// Check if this is a filtered view (drilling down into a specific session/window/pane)
 	isFilteredView := sessionID != "" || windowID != "" || paneID != ""

--- a/internal/tui/service/notification_service.go
+++ b/internal/tui/service/notification_service.go
@@ -354,11 +354,32 @@ func (s *DefaultNotificationService) FilterResolvableTmuxTargets(notifications [
 		return notifications
 	}
 
-	return appcore.KeepOnlyResolvableNotifications(notifications, appcore.DisplayNames{
+	domainNotifs := notificationsToDomainValues(notifications)
+	filtered := appcore.KeepOnlyResolvableNotifications(domainNotifs, appcore.DisplayNames{
 		Sessions: s.nameResolver.GetSessionNames(),
 		Windows:  s.nameResolver.GetWindowNames(),
 		Panes:    s.nameResolver.GetPaneNames(),
 	}, s.showStale)
+	return s.convertFromDomain(filtered)
+}
+
+func notificationsToDomainValues(notifs []notification.Notification) []domain.Notification {
+	values := make([]domain.Notification, 0, len(notifs))
+	for _, n := range notifs {
+		values = append(values, domain.Notification{
+			ID:            n.ID,
+			Timestamp:     n.Timestamp,
+			State:         domain.NotificationState(n.State),
+			Session:       n.Session,
+			Window:        n.Window,
+			Pane:          n.Pane,
+			Message:       n.Message,
+			PaneCreated:   n.PaneCreated,
+			Level:         domain.NotificationLevel(n.Level),
+			ReadTimestamp: n.ReadTimestamp,
+		})
+	}
+	return values
 }
 
 // ApplyFiltersAndSearch applies tab scope, then filters/search/sorting and stores filtered results.

--- a/internal/tui/service/stale_filter_test.go
+++ b/internal/tui/service/stale_filter_test.go
@@ -1,0 +1,62 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/cristianoliveira/tmux-intray/internal/notification"
+	"github.com/cristianoliveira/tmux-intray/internal/settings"
+)
+
+type testNameResolver struct {
+	sessions map[string]string
+	windows  map[string]string
+	panes    map[string]string
+}
+
+func (r *testNameResolver) ResolveSessionName(id string) string     { return r.sessions[id] }
+func (r *testNameResolver) ResolveWindowName(id string) string      { return r.windows[id] }
+func (r *testNameResolver) ResolvePaneName(id string) string        { return r.panes[id] }
+func (r *testNameResolver) GetSessionNames() map[string]string      { return r.sessions }
+func (r *testNameResolver) GetWindowNames() map[string]string       { return r.windows }
+func (r *testNameResolver) GetPaneNames() map[string]string         { return r.panes }
+func (r *testNameResolver) SetSessionNames(names map[string]string) { r.sessions = names }
+func (r *testNameResolver) SetWindowNames(names map[string]string)  { r.windows = names }
+func (r *testNameResolver) SetPaneNames(names map[string]string)    { r.panes = names }
+
+func TestApplyFiltersAndSearchHidesStaleTmuxTargetsByDefault(t *testing.T) {
+	svc := NewNotificationService(nil, &testNameResolver{
+		sessions: map[string]string{"$1": "work"},
+		windows:  map[string]string{"@1": "editor"},
+		panes:    map[string]string{"%1": "shell"},
+	})
+	svc.SetNotifications([]notification.Notification{
+		{ID: 1, Session: "$1", Window: "@1", Pane: "%1", Message: "live", State: "active"},
+		{ID: 2, Session: "$2", Window: "@2", Pane: "%2", Message: "stale", State: "active"},
+	})
+
+	svc.ApplyFiltersAndSearch(settings.TabAll, "", "", "", "", "", "", "", "timestamp", "desc")
+
+	got := svc.GetFilteredNotifications()
+	if len(got) != 1 || got[0].Message != "live" {
+		t.Fatalf("expected only live notification, got %#v", got)
+	}
+}
+
+func TestApplyFiltersAndSearchShowsStaleTmuxTargetsWhenEnabled(t *testing.T) {
+	svc := NewNotificationService(nil, &testNameResolver{
+		sessions: map[string]string{"$1": "work"},
+		windows:  map[string]string{"@1": "editor"},
+		panes:    map[string]string{"%1": "shell"},
+	})
+	svc.SetShowStale(true)
+	svc.SetNotifications([]notification.Notification{
+		{ID: 1, Session: "$1", Window: "@1", Pane: "%1", Message: "live", State: "active"},
+		{ID: 2, Session: "$2", Window: "@2", Pane: "%2", Message: "stale", State: "active"},
+	})
+
+	svc.ApplyFiltersAndSearch(settings.TabAll, "", "", "", "", "", "", "", "timestamp", "desc")
+
+	if got := svc.GetFilteredNotifications(); len(got) != 2 {
+		t.Fatalf("expected live and stale notifications, got %#v", got)
+	}
+}

--- a/internal/tui/service/tmux_coordinator.go
+++ b/internal/tui/service/tmux_coordinator.go
@@ -4,6 +4,7 @@ package service
 import (
 	"fmt"
 
+	appcore "github.com/cristianoliveira/tmux-intray/internal/app"
 	"github.com/cristianoliveira/tmux-intray/internal/core"
 	"github.com/cristianoliveira/tmux-intray/internal/errors"
 	"github.com/cristianoliveira/tmux-intray/internal/tmux"
@@ -142,26 +143,17 @@ func (c *DefaultRuntimeCoordinator) ListPanes() (map[string]string, error) {
 
 // GetSessionName returns the name of a session by its ID.
 func (c *DefaultRuntimeCoordinator) GetSessionName(sessionID string) (string, error) {
-	if name, ok := c.sessionNames[sessionID]; ok {
-		return name, nil
-	}
-	return sessionID, nil
+	return c.ResolveSessionName(sessionID), nil
 }
 
 // GetWindowName returns the name of a window by its ID.
 func (c *DefaultRuntimeCoordinator) GetWindowName(windowID string) (string, error) {
-	if name, ok := c.windowNames[windowID]; ok {
-		return name, nil
-	}
-	return windowID, nil
+	return c.ResolveWindowName(windowID), nil
 }
 
 // GetPaneName returns the name of a pane by its ID.
 func (c *DefaultRuntimeCoordinator) GetPaneName(paneID string) (string, error) {
-	if name, ok := c.paneNames[paneID]; ok {
-		return name, nil
-	}
-	return paneID, nil
+	return c.ResolvePaneName(paneID), nil
 }
 
 // RefreshNames refreshes cached session, window, and pane names.
@@ -237,24 +229,15 @@ func (c *DefaultRuntimeCoordinator) SetPaneNames(names map[string]string) {
 
 // ResolveSessionName converts a session ID to a name.
 func (c *DefaultRuntimeCoordinator) ResolveSessionName(sessionID string) string {
-	if name, ok := c.sessionNames[sessionID]; ok {
-		return name
-	}
-	return sessionID
+	return appcore.DisplayNames{Sessions: c.sessionNames}.Resolve("session", sessionID)
 }
 
 // ResolveWindowName converts a window ID to a name.
 func (c *DefaultRuntimeCoordinator) ResolveWindowName(windowID string) string {
-	if name, ok := c.windowNames[windowID]; ok {
-		return name
-	}
-	return windowID
+	return appcore.DisplayNames{Windows: c.windowNames}.Resolve("window", windowID)
 }
 
 // ResolvePaneName converts a pane ID to a name.
 func (c *DefaultRuntimeCoordinator) ResolvePaneName(paneID string) string {
-	if name, ok := c.paneNames[paneID]; ok {
-		return name
-	}
-	return paneID
+	return appcore.DisplayNames{Panes: c.paneNames}.Resolve("pane", paneID)
 }

--- a/internal/tui/service/tmux_coordinator_test.go
+++ b/internal/tui/service/tmux_coordinator_test.go
@@ -1,0 +1,57 @@
+package service
+
+import "testing"
+
+func TestRuntimeCoordinatorGetNamesUsesReadableFallbackForStaleTmuxIDs(t *testing.T) {
+	coordinator := &DefaultRuntimeCoordinator{
+		sessionNames: map[string]string{},
+		windowNames:  map[string]string{},
+		paneNames:    map[string]string{},
+	}
+
+	if got, err := coordinator.GetSessionName("$180"); err != nil || got != "stale-session:$180" {
+		t.Fatalf("GetSessionName() = %q, %v; want %q, nil", got, err, "stale-session:$180")
+	}
+	if got, err := coordinator.GetWindowName("@329"); err != nil || got != "stale-window:@329" {
+		t.Fatalf("GetWindowName() = %q, %v; want %q, nil", got, err, "stale-window:@329")
+	}
+	if got, err := coordinator.GetPaneName("%703"); err != nil || got != "stale-pane:%703" {
+		t.Fatalf("GetPaneName() = %q, %v; want %q, nil", got, err, "stale-pane:%703")
+	}
+}
+
+func TestRuntimeCoordinatorResolveNamesUsesReadableFallbackForStaleTmuxIDs(t *testing.T) {
+	coordinator := &DefaultRuntimeCoordinator{
+		sessionNames: map[string]string{},
+		windowNames:  map[string]string{},
+		paneNames:    map[string]string{},
+	}
+
+	if got := coordinator.ResolveSessionName("$180"); got != "stale-session:$180" {
+		t.Fatalf("ResolveSessionName() = %q, want %q", got, "stale-session:$180")
+	}
+	if got := coordinator.ResolveWindowName("@329"); got != "stale-window:@329" {
+		t.Fatalf("ResolveWindowName() = %q, want %q", got, "stale-window:@329")
+	}
+	if got := coordinator.ResolvePaneName("%703"); got != "stale-pane:%703" {
+		t.Fatalf("ResolvePaneName() = %q, want %q", got, "stale-pane:%703")
+	}
+}
+
+func TestRuntimeCoordinatorResolveNamesKeepsKnownTmuxNames(t *testing.T) {
+	coordinator := &DefaultRuntimeCoordinator{
+		sessionNames: map[string]string{"$1": "work"},
+		windowNames:  map[string]string{"@2": "editor"},
+		paneNames:    map[string]string{"%3": "server"},
+	}
+
+	if got := coordinator.ResolveSessionName("$1"); got != "work" {
+		t.Fatalf("ResolveSessionName() = %q, want %q", got, "work")
+	}
+	if got := coordinator.ResolveWindowName("@2"); got != "editor" {
+		t.Fatalf("ResolveWindowName() = %q, want %q", got, "editor")
+	}
+	if got := coordinator.ResolvePaneName("%3"); got != "server" {
+		t.Fatalf("ResolvePaneName() = %q, want %q", got, "server")
+	}
+}

--- a/internal/tui/state/model.go
+++ b/internal/tui/state/model.go
@@ -47,6 +47,7 @@ type Model struct {
 	settingsSvc    *settingsService
 	// UI render options
 	groupHeaderOptions settings.GroupHeaderOptions
+	showStale          bool
 
 	// Services - implementing BubbleTea nested model pattern
 	treeService         model.TreeService

--- a/internal/tui/state/model_bench_test.go
+++ b/internal/tui/state/model_bench_test.go
@@ -440,6 +440,8 @@ type dummyNotificationService struct {
 	filtered      []notification.Notification
 }
 
+func (d *dummyNotificationService) SetShowStale(show bool) {}
+
 func (d *dummyNotificationService) FilterNotifications(notifications []notification.Notification, query string) []notification.Notification {
 	if query == "" {
 		return notifications

--- a/internal/tui/state/model_stale.go
+++ b/internal/tui/state/model_stale.go
@@ -1,0 +1,9 @@
+package state
+
+// SetShowStale controls whether notifications for stale tmux targets remain visible.
+func (m *Model) SetShowStale(show bool) {
+	m.showStale = show
+	if svc, ok := m.notificationService.(interface{ SetShowStale(bool) }); ok {
+		svc.SetShowStale(show)
+	}
+}

--- a/internal/tui/state/model_test.go
+++ b/internal/tui/state/model_test.go
@@ -2239,10 +2239,19 @@ func TestUpdateViewportContentGroupedViewRendersMixedNodes(t *testing.T) {
 	groupNode := model.getVisibleNodesForTest()[0]
 	require.NotNil(t, groupNode)
 
+	expectedGroupDisplay := groupNode.Display
+	switch groupNode.Kind {
+	case uimodel.NodeKindSession:
+		expectedGroupDisplay = model.getSessionName(groupNode.Title)
+	case uimodel.NodeKindWindow:
+		expectedGroupDisplay = model.getWindowName(groupNode.Title)
+	case uimodel.NodeKindPane:
+		expectedGroupDisplay = model.getPaneName(groupNode.Title)
+	}
 	expectedGroupRow := render.RenderGroupRow(render.GroupRow{
 		Node: &render.GroupNode{
 			Title:       groupNode.Title,
-			Display:     groupNode.Display,
+			Display:     expectedGroupDisplay,
 			Expanded:    groupNode.Expanded,
 			Count:       groupNode.Count,
 			UnreadCount: groupNode.UnreadCount,
@@ -2265,8 +2274,10 @@ func TestUpdateViewportContentGroupedViewRendersMixedNodes(t *testing.T) {
 	}
 	require.NotNil(t, leafNode)
 
+	expectedLeafNotification := *leafNode.Notification
+	expectedLeafNotification.Pane = model.getPaneName(expectedLeafNotification.Pane)
 	expectedLeafRow := render.Row(render.RowState{
-		Notification: *leafNode.Notification,
+		Notification: expectedLeafNotification,
 		SessionName:  model.getSessionName(leafNode.Notification.Session),
 		Width:        model.uiState.GetWidth(),
 		Selected:     leafIndex == model.uiState.GetCursor(),
@@ -2317,8 +2328,10 @@ func TestUpdateViewportContentGroupedViewHighlightsLeafRow(t *testing.T) {
 	model.updateViewportContent()
 
 	content := model.uiState.GetViewport().View()
+	expectedLeafNotification := *leafNode.Notification
+	expectedLeafNotification.Pane = model.getPaneName(expectedLeafNotification.Pane)
 	expectedLeafRow := render.Row(render.RowState{
-		Notification: *leafNode.Notification,
+		Notification: expectedLeafNotification,
 		SessionName:  model.getSessionName(leafNode.Notification.Session),
 		Width:        model.uiState.GetWidth(),
 		Selected:     true,
@@ -2326,10 +2339,19 @@ func TestUpdateViewportContentGroupedViewHighlightsLeafRow(t *testing.T) {
 	})
 	assert.Contains(t, content, expectedLeafRow)
 
+	expectedGroupDisplay := groupNode.Display
+	switch groupNode.Kind {
+	case uimodel.NodeKindSession:
+		expectedGroupDisplay = model.getSessionName(groupNode.Title)
+	case uimodel.NodeKindWindow:
+		expectedGroupDisplay = model.getWindowName(groupNode.Title)
+	case uimodel.NodeKindPane:
+		expectedGroupDisplay = model.getPaneName(groupNode.Title)
+	}
 	expectedGroupRow := render.RenderGroupRow(render.GroupRow{
 		Node: &render.GroupNode{
 			Title:       groupNode.Title,
-			Display:     groupNode.Display,
+			Display:     expectedGroupDisplay,
 			Expanded:    groupNode.Expanded,
 			Count:       groupNode.Count,
 			UnreadCount: groupNode.UnreadCount,

--- a/internal/tui/state/model_test.go
+++ b/internal/tui/state/model_test.go
@@ -85,6 +85,7 @@ func newTestModel(t *testing.T, notifications []notification.Notification) *Mode
 		search.WithPaneNames(runtimeCoordinator.GetPaneNames()),
 	)
 	notificationService := service.NewNotificationService(searchProvider, runtimeCoordinator)
+	notificationService.SetShowStale(true)
 	notificationService.SetNotifications(notifications)
 
 	// Create model without loading from storage
@@ -196,6 +197,7 @@ func createTestModelFromNotifications(t *testing.T, notifications []notification
 		search.WithPaneNames(runtimeCoordinator.GetPaneNames()),
 	)
 	notificationService := service.NewNotificationService(searchProvider, runtimeCoordinator)
+	notificationService.SetShowStale(true)
 	notificationService.SetNotifications(notifications)
 
 	// Create model without loading from storage
@@ -231,12 +233,11 @@ func stubSessionFetchers(t *testing.T) *tmux.MockClient {
 	t.Helper()
 
 	mockClient := new(tmux.MockClient)
-	// Mock ListSessions to return empty map
-	mockClient.On("ListSessions").Return(map[string]string{}, nil)
-	// Mock ListWindows to return empty map
-	mockClient.On("ListWindows").Return(map[string]string{}, nil)
-	// Mock ListPanes to return empty map
-	mockClient.On("ListPanes").Return(map[string]string{}, nil)
+	// Return nil name maps so generic model tests do not exercise stale-target filtering.
+	var noNames map[string]string
+	mockClient.On("ListSessions").Return(noNames, nil)
+	mockClient.On("ListWindows").Return(noNames, nil)
+	mockClient.On("ListPanes").Return(noNames, nil)
 	mockClient.On("GetSessionName", mock.Anything).Return("", stderrors.New("session not found"))
 
 	return mockClient
@@ -340,15 +341,15 @@ func (t *testRuntimeCoordinator) ResolvePaneName(paneID string) string {
 }
 
 func (t *testRuntimeCoordinator) GetSessionNames() map[string]string {
-	return map[string]string{}
+	return nil
 }
 
 func (t *testRuntimeCoordinator) GetWindowNames() map[string]string {
-	return map[string]string{}
+	return nil
 }
 
 func (t *testRuntimeCoordinator) GetPaneNames() map[string]string {
-	return map[string]string{}
+	return nil
 }
 
 func (t *testRuntimeCoordinator) SetSessionNames(names map[string]string) {}
@@ -391,6 +392,7 @@ func BenchmarkComputeVisibleNodesCache(b *testing.B) {
 	}
 
 	notificationService := service.NewNotificationService(nil, nil)
+	notificationService.SetShowStale(true)
 	notificationService.SetNotifications(notifications)
 	model := &Model{
 		uiState:             NewUIState(),
@@ -1523,6 +1525,7 @@ func TestApplySearchFilterWithMockProvider(t *testing.T) {
 	runtimeCoordinator := service.NewRuntimeCoordinator(mockClient)
 	treeService := service.NewTreeService(uiState.GetGroupBy())
 	notificationService := service.NewNotificationService(mockProvider, runtimeCoordinator)
+	notificationService.SetShowStale(true)
 
 	model := Model{
 		uiState:             uiState,


### PR DESCRIPTION
## Summary
- Hide notifications for stale tmux session/window/pane targets in standard CLI and TUI views by default
- Add `--show-stale` to CLI list and TUI to explicitly include stale targets
- Centralize stale-target visibility in `internal/app` using `domain.Notification`
- Keep `cmd/tmux-intray` as entrypoint-only by moving helper logic to `internal/`

## Verification
- `make lint`
- `go test ./...`
- Manual CLI check: `go run ./cmd/tmux-intray list --format=simple | head -12`
- Manual CLI stale check: `go run ./cmd/tmux-intray list --format=simple --show-stale | head -5`