### PR TITLE
docs: add package-level agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,24 +1,37 @@
-## Project Philosophy
+# Repository Guidance
 
-This project follows minimalist, Unix‑style principles focused on quiet notifications, persistent storage, and composable design. See [Project Philosophy](docs/philosophy.md) for the guiding principles that inform all design decisions.
+## Product compass
 
-## Development Guide
+Build a quiet, persistent, tmux-aware notification inbox. Prefer composable output, explicit behavior, minimal configuration, and one obvious path. See [docs/philosophy.md](docs/philosophy.md).
 
-Detailed development guidelines in [DEVELOPMENT.md](./DEVELOPMENT.md).
+## Global engineering rules
 
-### Code Placement Rules
+- Use test-driven development; cover happy and unhappy paths.
+- Keep Cobra commands as composition and transport code. Put reusable behavior under `internal/`.
+- Preserve dependency direction defined in [docs/design/import-layering-map.md](docs/design/import-layering-map.md).
+- Inject dependencies through interfaces or factories; composition roots own concrete wiring.
+- Use lowercase errors without trailing punctuation. Wrap causes with `%w`.
+- Use `snake_case` for TOML keys and sections.
+- Do not hand-edit generated code under `internal/storage/sqlite/sqlcgen/`.
 
-- `cmd/tmux-intray/` must stay pure entrypoints: command wiring, flags, validation, dependency injection, and calls into internal packages only.
-- Do not add business logic or helper modules under `cmd/tmux-intray/`; move reusable behavior to `internal/` and test it there.
+## Local guidance index
 
-### Essential Documentation
+Read nearest nested `AGENTS.md` before changing code:
 
-- **Package Structure**: See [Go Package Structure](./docs/design/go-package-structure.md)
-- **Configuration**: See [Configuration Guide](./docs/configuration.md)
-- **CLI Reference**: See [CLI Reference](./docs/cli/CLI_REFERENCE.md)
-- **Hooks System**: See [Hooks Documentation](./docs/hooks.md)
-- **Troubleshooting**: See [Troubleshooting Guide](./docs/troubleshooting.md)
-- **Code design**: See [design](./docs/design/)
+- [`cmd/tmux-intray/`](cmd/tmux-intray/AGENTS.md) — CLI composition and commands
+- [`internal/app/`](internal/app/AGENTS.md) — use-case orchestration
+- [`internal/core/`](internal/core/AGENTS.md) — notification and tmux business behavior
+- [`internal/domain/`](internal/domain/AGENTS.md) — pure domain model
+- [`internal/storage/`](internal/storage/AGENTS.md) — persistence boundary
+- [`internal/tmux/`](internal/tmux/AGENTS.md) — tmux process adapter
+- [`internal/config/`](internal/config/AGENTS.md) — TOML configuration
+- [`internal/hooks/`](internal/hooks/AGENTS.md) — hook execution
+- [`internal/settings/`](internal/settings/AGENTS.md) — persisted user settings
+- [`internal/tui/`](internal/tui/AGENTS.md) — interactive presentation
+- [`internal/format/`](internal/format/AGENTS.md) — CLI output
+- [`internal/search/`](internal/search/AGENTS.md) — search strategies
+
+Development commands and full package map live in [DEVELOPMENT.md](DEVELOPMENT.md).
 
 
 ## Landing the Plane (Session Completion)

--- a/cmd/tmux-intray/AGENTS.md
+++ b/cmd/tmux-intray/AGENTS.md
@@ -1,0 +1,18 @@
+# CLI Commands
+
+## Responsibility
+
+This package is the composition root and Cobra transport layer. It owns flags, argument binding, dependency factories, command registration, and process exit behavior.
+
+## Boundaries
+
+- Keep commands thin; delegate reusable workflows to `internal/app` or `internal/core`.
+- Wire concrete storage, core, search, settings, and TUI dependencies in `deps.go`.
+- Do not add domain rules, persistence queries, or tmux process logic here.
+- Preserve command output and exit-code compatibility unless change is intentional.
+
+## Tests
+
+Add or update adjacent `*_test.go` files. Inject factories or narrow command interfaces rather than invoking real tmux or user storage.
+
+Run: `go test ./cmd/tmux-intray`

--- a/internal/AGENTS.md
+++ b/internal/AGENTS.md
@@ -1,0 +1,9 @@
+# Internal Packages
+
+All packages here are private to this module. Follow nearest nested guidance when present.
+
+- Keep dependency direction inward: presentation/application/infrastructure may use domain; domain must not import outward.
+- Prefer narrow consumer-owned interfaces and explicit constructor injection.
+- Keep package responsibilities small; do not create generic utility dumping grounds.
+- Place tests beside implementation and match local table-driven/fake patterns.
+- Run the changed package tests first, then `go test ./...` and dependency guardrails.

--- a/internal/app/AGENTS.md
+++ b/internal/app/AGENTS.md
@@ -1,0 +1,18 @@
+# Application Use Cases
+
+## Responsibility
+
+Orchestrate CLI-facing workflows between parsed inputs and injected clients. This layer coordinates validation, defaults, calls, and user-facing outcomes without owning infrastructure.
+
+## Boundaries
+
+- Model each workflow with a small input and injected interface.
+- Keep Cobra types, SQLite details, and direct tmux command execution out.
+- Put reusable domain rules in `internal/domain`; put notification lifecycle behavior in `internal/core`.
+- Fail explicitly and wrap dependency errors with operation context.
+
+## Tests
+
+Use fakes for interfaces. Cover successful orchestration and each dependency/error branch.
+
+Run: `go test ./internal/app`

--- a/internal/config/AGENTS.md
+++ b/internal/config/AGENTS.md
@@ -1,0 +1,18 @@
+# Configuration
+
+## Responsibility
+
+Load, merge, expose, and validate application configuration from TOML and supported environment overrides.
+
+## Boundaries
+
+- TOML keys and sections must use `snake_case`.
+- Keep defaults and precedence explicit and centralized.
+- Do not perform application workflows while loading configuration.
+- Validate user input at the configuration boundary with actionable errors.
+
+## Tests
+
+Use temporary config directories and isolated environment variables. Cover defaults, overrides, malformed TOML, and invalid values.
+
+Run: `go test ./internal/config && ./scripts/lint-toml.sh`

--- a/internal/core/AGENTS.md
+++ b/internal/core/AGENTS.md
@@ -1,0 +1,18 @@
+# Core Application Logic
+
+## Responsibility
+
+Own notification lifecycle and tmux-aware application behavior: add, list, dismiss, read state, cleanup, context association, and navigation.
+
+## Boundaries
+
+- Depend on ports and injected collaborators; do not construct CLI commands.
+- Keep storage SQL in `internal/storage` and low-level tmux execution in `internal/tmux`.
+- Reuse domain types and validation instead of parallel representations.
+- Preserve notification context: session, window, pane, and pane creation identity.
+
+## Tests
+
+Prefer fakes and temporary storage. Cover associated and tmuxless behavior plus dependency failures.
+
+Run: `go test ./internal/core`

--- a/internal/domain/AGENTS.md
+++ b/internal/domain/AGENTS.md
@@ -1,0 +1,18 @@
+# Domain Model
+
+## Responsibility
+
+Define pure notification types, states, levels, filters, sorting, grouping, and repository contracts.
+
+## Boundaries
+
+- Keep this package free of I/O, CLI, TUI, SQLite, configuration, and tmux dependencies.
+- Express invariants in domain types or pure functions.
+- Prefer typed states and levels over raw strings at boundaries.
+- Avoid importing infrastructure to make a domain operation convenient.
+
+## Tests
+
+Use table-driven deterministic tests for invariants and transformations. Test invalid values and empty collections.
+
+Run: `go test ./internal/domain`

--- a/internal/format/AGENTS.md
+++ b/internal/format/AGENTS.md
@@ -1,0 +1,18 @@
+# CLI Formatting
+
+## Responsibility
+
+Transform notifications and status data into stable table, simple, compact, JSON, or template-oriented CLI output.
+
+## Boundaries
+
+- Keep formatting pure where possible: values in, text out.
+- Do not query storage or tmux from formatters.
+- Preserve machine-readable output contracts; JSON changes require compatibility tests.
+- Keep ANSI color decisions explicit and avoid colors in structured output.
+
+## Tests
+
+Use exact-output and JSON semantic assertions. Cover empty values, special characters, and each supported format.
+
+Run: `go test ./internal/format`

--- a/internal/formatter/AGENTS.md
+++ b/internal/formatter/AGENTS.md
@@ -1,0 +1,10 @@
+# Status Templates
+
+Own status presets, template parsing, and variable substitution.
+
+- Keep template expansion deterministic and independent of storage/tmux I/O.
+- Define variables and presets in one source of truth.
+- Return invalid template or unknown preset errors explicitly.
+- Preserve existing preset output unless change is intentional and tested.
+
+Run: `go test ./internal/formatter`

--- a/internal/hooks/AGENTS.md
+++ b/internal/hooks/AGENTS.md
@@ -1,0 +1,18 @@
+# Hooks
+
+## Responsibility
+
+Discover and execute documented pre/post hooks while managing asynchronous work and shutdown flushing.
+
+## Boundaries
+
+- Keep hook points and payloads explicit and stable.
+- Isolate process execution and runtime configuration from core notification rules.
+- Never silently discard hook failures; report or log according to calling contract.
+- Ensure shutdown waits for pending work without leaking goroutines.
+
+## Tests
+
+Use temporary executable fixtures and bounded timeouts. Cover success, failure, missing hooks, cancellation, and shutdown.
+
+Run: `go test ./internal/hooks`

--- a/internal/ports/AGENTS.md
+++ b/internal/ports/AGENTS.md
@@ -1,0 +1,10 @@
+# Ports
+
+Define stable boundaries used by application logic to access external capabilities.
+
+- Keep interfaces narrow and expressed with domain types.
+- Do not import concrete infrastructure or presentation packages.
+- Prefer consumer-driven contracts over mirrors of implementation APIs.
+- Contract changes require tests for all adapters and consumers.
+
+Verify with: `go test ./...`

--- a/internal/search/AGENTS.md
+++ b/internal/search/AGENTS.md
@@ -1,0 +1,18 @@
+# Search
+
+## Responsibility
+
+Provide interchangeable substring, token, and regular-expression matching strategies over notification and tmux display data.
+
+## Boundaries
+
+- Implement the shared provider contract; callers select strategy through dependency wiring.
+- Keep matching deterministic and free of I/O.
+- Return regex compilation or input errors explicitly.
+- Centralize case-sensitivity and display-name options rather than duplicating matching logic.
+
+## Tests
+
+Use table-driven tests for matches, misses, empty input, case behavior, names, and invalid regexes.
+
+Run: `go test ./internal/search`

--- a/internal/settings/AGENTS.md
+++ b/internal/settings/AGENTS.md
@@ -1,0 +1,18 @@
+# Settings
+
+## Responsibility
+
+Define, validate, load, save, and reset persisted user preferences, including TUI tabs and grouping choices.
+
+## Boundaries
+
+- Keep defaults centralized and validation explicit.
+- Separate settings persistence from configuration semantics.
+- Do not let TUI state mutate persisted data except through this package's manager contracts.
+- Use atomic or otherwise safe persistence behavior.
+
+## Tests
+
+Use temporary paths. Cover defaults, round trips, malformed files, invalid values, and reset behavior.
+
+Run: `go test ./internal/settings`

--- a/internal/storage/AGENTS.md
+++ b/internal/storage/AGENTS.md
@@ -1,0 +1,19 @@
+# Storage
+
+## Responsibility
+
+Implement persistent notification storage and adapt SQLite records to domain repository contracts.
+
+## Boundaries
+
+- Keep storage-specific types behind adapters.
+- Preserve transactional behavior and explicit locking where required.
+- Put SQLite implementation in `sqlite/`; callers should depend on storage or domain interfaces.
+- Never hand-edit `sqlite/sqlcgen/`; regenerate it from SQL/schema sources.
+- Map database values to domain states and levels in one place.
+
+## Tests
+
+Use isolated temporary databases. Cover persistence, reopening, invalid data, cleanup, and transaction failure paths.
+
+Run: `go test ./internal/storage/...`

--- a/internal/storage/sqlite/AGENTS.md
+++ b/internal/storage/sqlite/AGENTS.md
@@ -1,0 +1,10 @@
+# SQLite Implementation
+
+Implement storage operations, schema integration, and sqlc query use for notification persistence.
+
+- Keep SQL behavior and record mapping inside storage boundaries.
+- Preserve transaction, cleanup, and concurrency semantics.
+- Treat `sqlcgen/` as generated output; change source SQL/schema and run `make sqlc-generate`.
+- Test with isolated temporary databases and verify behavior after reopening.
+
+Run: `go test ./internal/storage/sqlite`

--- a/internal/tmux/AGENTS.md
+++ b/internal/tmux/AGENTS.md
@@ -1,0 +1,18 @@
+# Tmux Adapter
+
+## Responsibility
+
+Wrap tmux process execution, context discovery, target listing, and pane navigation behind a mockable client.
+
+## Boundaries
+
+- Keep command construction and output parsing here.
+- Return structured context and explicit errors; do not print user-facing messages.
+- Do not add notification lifecycle or CLI flag behavior.
+- Inject command runners in tests; never require a live tmux server for unit tests.
+
+## Tests
+
+Test exact arguments, parsing, missing-server behavior, malformed output, and runner failures.
+
+Run: `go test ./internal/tmux`

--- a/internal/tui/AGENTS.md
+++ b/internal/tui/AGENTS.md
@@ -1,0 +1,23 @@
+# Terminal UI
+
+## Responsibility
+
+Provide interactive Bubble Tea presentation while keeping state transitions, services, rendering, and external interactions separated.
+
+## Package map
+
+- `app/`: construct and run TUI.
+- `model/`: contracts shared across TUI components.
+- `state/`: Bubble Tea model and update transitions.
+- `service/`: notification, tree, and tmux coordination.
+- `render/`: pure terminal views.
+- `controller/`: interaction and jump decisions.
+
+## Boundaries
+
+- State owns transitions, not storage or tmux implementation details.
+- Renderers must not perform I/O or mutate state.
+- Put external effects behind model interfaces and services.
+- Preserve keyboard behavior and inline error feedback with focused tests.
+
+Run: `go test ./internal/tui/...`

--- a/internal/tui/app/AGENTS.md
+++ b/internal/tui/app/AGENTS.md
@@ -1,0 +1,10 @@
+# TUI Application
+
+Construct and run Bubble Tea with configured repositories, services, settings, and tmux collaborators.
+
+- Treat this package as TUI composition, not business logic.
+- Pass configured clients into services and state.
+- Keep terminal startup/shutdown errors explicit.
+- Test construction and run behavior through injected interfaces; avoid real terminal or tmux dependencies.
+
+Run: `go test ./internal/tui/app`

--- a/internal/tui/controller/AGENTS.md
+++ b/internal/tui/controller/AGENTS.md
@@ -1,0 +1,10 @@
+# TUI Interaction Controller
+
+Resolve user interactions into explicit navigation and jump decisions.
+
+- Keep interaction decisions separate from rendering and storage.
+- Depend on contracts and domain identifiers, not concrete TUI state internals.
+- Make stale or missing targets explicit outcomes.
+- Test valid targets, absent context, stale panes, and collaborator failures.
+
+Run: `go test ./internal/tui/controller`

--- a/internal/tui/model/AGENTS.md
+++ b/internal/tui/model/AGENTS.md
@@ -1,0 +1,10 @@
+# TUI Contracts
+
+Define narrow interfaces shared by TUI state, services, rendering, and controllers.
+
+- Keep contracts presentation-focused and implementation-independent.
+- Add methods only for demonstrated consumer needs.
+- Avoid concrete storage, tmux, or Bubble Tea implementation types where a domain value suffices.
+- Interface changes require updating fakes and all implementations.
+
+Verify consumers with: `go test ./internal/tui/...`

--- a/internal/tui/render/AGENTS.md
+++ b/internal/tui/render/AGENTS.md
@@ -1,0 +1,10 @@
+# TUI Rendering
+
+Render current UI/domain state into terminal text.
+
+- Keep rendering pure: state in, string out.
+- Do not load data, call tmux, persist settings, or mutate model state.
+- Centralize width, truncation, selection, grouping, and style rules.
+- Test exact visible behavior across empty, narrow, selected, grouped, and error states.
+
+Run: `go test ./internal/tui/render`

--- a/internal/tui/service/AGENTS.md
+++ b/internal/tui/service/AGENTS.md
@@ -1,0 +1,10 @@
+# TUI Services
+
+Implement notification filtering/grouping, tree operations, and tmux runtime coordination behind `internal/tui/model` contracts.
+
+- Keep services independent of Bubble Tea message dispatch.
+- Reuse domain filters, grouping, sorting, and search providers.
+- Isolate tmux effects in runtime coordination.
+- Keep tree transformations deterministic and test navigation boundaries.
+
+Run: `go test ./internal/tui/service`

--- a/internal/tui/state/AGENTS.md
+++ b/internal/tui/state/AGENTS.md
@@ -1,0 +1,10 @@
+# TUI State
+
+Own Bubble Tea `Model`, messages, key handling, cursor/tree state, settings state, and update transitions.
+
+- Keep `Update` shallow by dispatching typed messages to focused handlers.
+- Return commands for effects; do not execute storage or tmux I/O directly in transitions.
+- Keep state changes deterministic and rendering outside this package where practical.
+- Add tests for key paths, boundaries, empty data, errors, and asynchronous result messages.
+
+Run: `go test ./internal/tui/state`


### PR DESCRIPTION
## Summary

- turn root AGENTS.md into concise repository guidance and nested index
- add package-level ownership and boundary guidance across CLI, application, domain, infrastructure, and TUI
- document local test commands and generated SQLite constraints

## Validation

- `./scripts/check-import-deny-rules.sh`
- `go test ./...`