### PR TITLE
fix(pi): ignore bash tool errors in intray

### DIFF
--- a/pi/agent/extensions/tmux-intray/README.md
+++ b/pi/agent/extensions/tmux-intray/README.md
@@ -7,7 +7,6 @@ Send Pi agent lifecycle notifications to `tmux-intray`.
 The extension subscribes to Pi events and writes quiet tmux notifications:
 
 - `agent_end` → `tmux-intray add --level=info -- "Task completed"`
-- failed `tool_result` → `tmux-intray add --level=error -- "Tool error: <tool>"`
 - `session_shutdown` → `tmux-intray add --level=warning -- "Session shutdown"`
 
 It captures the current tmux session, window, and pane with:

--- a/pi/agent/extensions/tmux-intray/README.md
+++ b/pi/agent/extensions/tmux-intray/README.md
@@ -7,6 +7,7 @@ Send Pi agent lifecycle notifications to `tmux-intray`.
 The extension subscribes to Pi events and writes quiet tmux notifications:
 
 - `agent_end` → `tmux-intray add --level=info -- "Task completed"`
+- failed non-bash `tool_result` → `tmux-intray add --level=error -- "Tool error: <tool>"`
 - `session_shutdown` → `tmux-intray add --level=warning -- "Session shutdown"`
 
 It captures the current tmux session, window, and pane with:

--- a/pi/agent/extensions/tmux-intray/index.test.ts
+++ b/pi/agent/extensions/tmux-intray/index.test.ts
@@ -1,21 +1,50 @@
 import assert from "node:assert/strict";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 
 import tmuxIntrayExtension from "./index.ts";
 
-test("registers lifecycle notifications without tool error messages", async () => {
-  const handlers = new Map<string, () => Promise<void>>();
+type ToolResultEvent = { isError: boolean; toolName: string };
+type Handler = (event: ToolResultEvent) => Promise<void>;
+
+test("notifies for tool errors except bash errors", async (t) => {
+  const handlers = new Map<string, Handler>();
   const pi = {
-    on(eventName: string, handler: () => Promise<void>) {
+    on(eventName: string, handler: Handler) {
       handlers.set(eventName, handler);
     },
   };
 
   tmuxIntrayExtension(pi as never);
 
-  assert.deepEqual([...handlers.keys()], ["agent_end", "session_shutdown"]);
+  assert.deepEqual([...handlers.keys()], ["agent_end", "tool_result", "session_shutdown"]);
 
-  process.env.TMUX_INTRAY_PATH = "/usr/bin/true";
-  await handlers.get("agent_end")?.();
-  await handlers.get("session_shutdown")?.();
+  const tempDirectory = await mkdtemp(join(tmpdir(), "pi-tmux-intray-"));
+  const callsFile = join(tempDirectory, "calls");
+  const fakeIntray = join(tempDirectory, "tmux-intray");
+  await writeFile(fakeIntray, '#!/bin/sh\nprintf "%s\\n" "$*" >> "$TMUX_INTRAY_TEST_CALLS"\n');
+  await chmod(fakeIntray, 0o755);
+
+  const originalIntrayPath = process.env.TMUX_INTRAY_PATH;
+  process.env.TMUX_INTRAY_PATH = fakeIntray;
+  process.env.TMUX_INTRAY_TEST_CALLS = callsFile;
+  t.after(async () => {
+    if (originalIntrayPath === undefined) delete process.env.TMUX_INTRAY_PATH;
+    else process.env.TMUX_INTRAY_PATH = originalIntrayPath;
+    delete process.env.TMUX_INTRAY_TEST_CALLS;
+    await rm(tempDirectory, { recursive: true, force: true });
+  });
+
+  const toolResult = handlers.get("tool_result");
+  assert.ok(toolResult);
+
+  await toolResult({ isError: true, toolName: "bash" });
+  await toolResult({ isError: false, toolName: "read" });
+  await assert.rejects(readFile(callsFile, "utf8"), { code: "ENOENT" });
+
+  await toolResult({ isError: true, toolName: "read" });
+  const calls = await readFile(callsFile, "utf8");
+  assert.match(calls, /add --level=error .*-- Tool error: read\n$/);
 });

--- a/pi/agent/extensions/tmux-intray/index.test.ts
+++ b/pi/agent/extensions/tmux-intray/index.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import tmuxIntrayExtension from "./index.ts";
+
+test("registers lifecycle notifications without tool error messages", async () => {
+  const handlers = new Map<string, () => Promise<void>>();
+  const pi = {
+    on(eventName: string, handler: () => Promise<void>) {
+      handlers.set(eventName, handler);
+    },
+  };
+
+  tmuxIntrayExtension(pi as never);
+
+  assert.deepEqual([...handlers.keys()], ["agent_end", "session_shutdown"]);
+
+  process.env.TMUX_INTRAY_PATH = "/usr/bin/true";
+  await handlers.get("agent_end")?.();
+  await handlers.get("session_shutdown")?.();
+});

--- a/pi/agent/extensions/tmux-intray/index.ts
+++ b/pi/agent/extensions/tmux-intray/index.ts
@@ -48,7 +48,7 @@ async function getTmuxContext(): Promise<{ session: string; window: string; pane
   return { session, window, pane };
 }
 
-async function notify(level: "info" | "warning", message: string): Promise<void> {
+async function notify(level: "info" | "error" | "warning", message: string): Promise<void> {
   try {
     const cmd = getTmuxIntrayCommand();
     const ctx = await getTmuxContext();
@@ -69,6 +69,11 @@ async function notify(level: "info" | "warning", message: string): Promise<void>
 export default function tmuxIntrayExtension(pi: ExtensionAPI) {
   pi.on("agent_end", async () => {
     await notify("info", "Task completed");
+  });
+
+  pi.on("tool_result", async (event) => {
+    if (!event.isError || event.toolName === "bash") return;
+    await notify("error", `Tool error: ${event.toolName}`);
   });
 
   pi.on("session_shutdown", async () => {

--- a/pi/agent/extensions/tmux-intray/index.ts
+++ b/pi/agent/extensions/tmux-intray/index.ts
@@ -48,7 +48,7 @@ async function getTmuxContext(): Promise<{ session: string; window: string; pane
   return { session, window, pane };
 }
 
-async function notify(level: "info" | "error" | "warning", message: string): Promise<void> {
+async function notify(level: "info" | "warning", message: string): Promise<void> {
   try {
     const cmd = getTmuxIntrayCommand();
     const ctx = await getTmuxContext();
@@ -69,12 +69,6 @@ async function notify(level: "info" | "error" | "warning", message: string): Pro
 export default function tmuxIntrayExtension(pi: ExtensionAPI) {
   pi.on("agent_end", async () => {
     await notify("info", "Task completed");
-  });
-
-  pi.on("tool_result", async (event) => {
-    if (event.isError) {
-      await notify("error", `Tool error: ${event.toolName}`);
-    }
   });
 
   pi.on("session_shutdown", async () => {


### PR DESCRIPTION
## Summary

- notify on failed tool results for non-bash tools
- keep bash failures silent
- keep task completion and session shutdown notifications
- cover bash-error, non-error, and non-bash-error paths

## Verification

- `node --test --experimental-test-coverage --test-coverage-lines=75 --test-coverage-functions=75 pi/agent/extensions/tmux-intray/index.test.ts`
- `go test ./...`
- `bats tests`